### PR TITLE
feat: replace UUID-based identifiers with stable integer IDs

### DIFF
--- a/src/infrasys/__init__.py
+++ b/src/infrasys/__init__.py
@@ -10,7 +10,6 @@ TS_METADATA_FORMAT_VERSION = "1.0.0"
 TIME_SERIES_ASSOCIATIONS_TABLE = "time_series_associations"
 TIME_SERIES_METADATA_TABLE = "time_series_metadata"
 KEY_VALUE_STORE_TABLE = "key_value_store"
-SUPPLEMENTAL_ATTRIBUTE_ASSOCIATIONS_TABLE = "supplemental_attribute_associations"
 COMPONENT_ASSOCIATIONS_TABLE = "component_associations"
 SUPPLEMENTAL_ATTRIBUTE_ASSOCIATIONS_TABLE = "supplemental_attribute_associations"
 

--- a/src/infrasys/component.py
+++ b/src/infrasys/component.py
@@ -69,10 +69,13 @@ class Component(InfraSysBaseModelWithIdentifers):
 
 def serialize_component_reference(component: Component) -> dict[str, Any]:
     """Make a JSON serializable reference to a component."""
+    if component.id is None:
+        msg = f"Component {component.label} must be attached before it can be serialized"
+        raise ValueError(msg)
     return SerializedTypeMetadata.validate_python(
         SerializedComponentReference(
             module=component.__module__,
             type=component.__class__.__name__,
-            uuid=component.uuid,
+            id=component.id,
         ),
     ).model_dump(by_alias=True)

--- a/src/infrasys/component_associations.py
+++ b/src/infrasys/component_associations.py
@@ -1,9 +1,9 @@
 from typing import Optional, Type
-from uuid import UUID
 
 from loguru import logger
 
 from infrasys import COMPONENT_ASSOCIATIONS_TABLE, Component
+from infrasys.exceptions import ISOperationNotAllowed
 from infrasys.utils.classes import get_all_concrete_subclasses
 from infrasys.utils.metadata_utils import create_component_associations_table
 from infrasys.utils.sqlite import create_in_memory_db, execute
@@ -47,46 +47,55 @@ class ComponentAssociations:
 
     def list_child_components(
         self, component: Component, component_type: Optional[Type[Component]] = None
-    ) -> list[UUID]:
-        """Return a list of all component UUIDS that this component composes.
+    ) -> list[int]:
+        """Return a list of all component IDs that this component composes.
         For example, return the bus attached to a generator.
         """
-        where_clause = "WHERE component_uuid = ?"
-        params = [str(component.uuid)]
+        if component.id is None:
+            msg = f"{component.label} does not have an id assigned."
+            raise ISOperationNotAllowed(msg)
+        where_clause = "WHERE component_id = ?"
+        params = [component.id]
         if component_type is not None:
             res = _make_params_and_where_clause(component_type, "attached_component_type")
             params.extend(res[0])
             where_clause += res[1]
         query = (
-            f"SELECT attached_component_uuid FROM {COMPONENT_ASSOCIATIONS_TABLE} {where_clause}"
+            f"SELECT attached_component_id FROM {COMPONENT_ASSOCIATIONS_TABLE} {where_clause}"
         )
         cur = self._con.cursor()
-        return [UUID(x[0]) for x in execute(cur, query, params)]
+        return [x[0] for x in execute(cur, query, params)]
 
     def list_parent_components(
         self, component: Component, component_type: Optional[Type[Component]] = None
-    ) -> list[UUID]:
-        """Return a list of all component UUIDS that compose this component.
+    ) -> list[int]:
+        """Return a list of all component IDs that compose this component.
         For example, return all components connected to a bus.
         """
-        where_clause = "WHERE attached_component_uuid = ?"
-        params = [str(component.uuid)]
+        if component.id is None:
+            msg = f"{component.label} does not have an id assigned."
+            raise ISOperationNotAllowed(msg)
+        where_clause = "WHERE attached_component_id = ?"
+        params = [component.id]
         if component_type is not None:
             res = _make_params_and_where_clause(component_type, "component_type")
             params.extend(res[0])
             where_clause += res[1]
-        query = f"SELECT component_uuid FROM {COMPONENT_ASSOCIATIONS_TABLE} {where_clause}"
+        query = f"SELECT component_id FROM {COMPONENT_ASSOCIATIONS_TABLE} {where_clause}"
         cur = self._con.cursor()
-        return [UUID(x[0]) for x in execute(cur, query, params)]
+        return [x[0] for x in execute(cur, query, params)]
 
     def remove(self, component: Component) -> None:
         """Delete all rows with this component."""
+        if component.id is None:
+            msg = f"{component.label} does not have an id assigned."
+            raise ISOperationNotAllowed(msg)
         query = f"""
             DELETE
             FROM {COMPONENT_ASSOCIATIONS_TABLE}
-            WHERE component_uuid = ? OR attached_component_uuid = ?
+            WHERE component_id = ? OR attached_component_id = ?
         """
-        params = [str(component.uuid), str(component.uuid)]
+        params = [component.id, component.id]
         execute(self._con.cursor(), query, params)
         logger.debug("Removed all associations with component {}", component.label)
 
@@ -102,6 +111,8 @@ class ComponentAssociations:
     def _insert_rows(self, rows: list[tuple]) -> None:
         cur = self._con.cursor()
         placeholder = ",".join(["?"] * len(rows[0]))
+        component_ids = {(row[1],) for row in rows}.union({(row[3],) for row in rows})
+        cur.executemany("INSERT OR IGNORE INTO components(id) VALUES(?)", component_ids)
         query = f"INSERT INTO {COMPONENT_ASSOCIATIONS_TABLE} VALUES({placeholder})"
         try:
             cur.executemany(query, rows)
@@ -110,11 +121,17 @@ class ComponentAssociations:
 
     @staticmethod
     def _make_row(component: Component, attached_component: Component):
+        if component.id is None:
+            msg = f"{component.label} does not have an id assigned."
+            raise ISOperationNotAllowed(msg)
+        if attached_component.id is None:
+            msg = f"{attached_component.label} does not have an id assigned."
+            raise ISOperationNotAllowed(msg)
         return (
             None,
-            str(component.uuid),
+            component.id,
             type(component).__name__,
-            str(attached_component.uuid),
+            attached_component.id,
             type(attached_component).__name__,
         )
 

--- a/src/infrasys/component_manager.py
+++ b/src/infrasys/component_manager.py
@@ -1,5 +1,6 @@
 """Manages components"""
 
+import copy
 import itertools
 from collections import defaultdict
 from typing import Any, Callable, Iterable, Optional, Type
@@ -13,6 +14,7 @@ from infrasys.exceptions import (
     ISNotStored,
     ISOperationNotAllowed,
 )
+from infrasys.id_manager import IDManager
 from infrasys.models import make_label, get_class_and_name_from_label
 
 
@@ -24,7 +26,9 @@ class ComponentManager:
         auto_add_composed_components: bool,
     ) -> None:
         self._components: dict[Type, dict[str | None, list[Component]]] = {}
+        self._components_by_id: dict[int, Component] = {}
         self._components_by_uuid: dict[UUID, Component] = {}
+        self._id_manager = IDManager(next_id=1)
         self._auto_add_composed_components = auto_add_composed_components
         self._associations = ComponentAssociations()
 
@@ -84,7 +88,7 @@ class ComponentManager:
 
     def get_num_components(self) -> int:
         """Return the number of stored components."""
-        return len(self._components_by_uuid)
+        return len(self._components_by_id)
 
     def get_num_components_by_type(self) -> dict[Type, int]:
         """Return the number of stored components by type."""
@@ -103,6 +107,12 @@ class ComponentManager:
             Raised if there is more than one matching component.
         """
         class_name, name_or_uuid = get_class_and_name_from_label(label)
+        if isinstance(name_or_uuid, int):
+            component = self.get_by_id(name_or_uuid)
+            if type(component).__name__ == class_name:
+                return component
+            msg = f"No component with {label=} is stored."
+            raise ISNotStored(msg)
         if isinstance(name_or_uuid, UUID):
             return self.get_by_uuid(name_or_uuid)
 
@@ -126,7 +136,7 @@ class ComponentManager:
 
     def has_component(self, component) -> bool:
         """Return True if the component is attached."""
-        return component.uuid in self._components_by_uuid
+        return component.id in self._components_by_id if component.id is not None else False
 
     def iter(
         self, *component_types: Type[Component], filter_func: Callable | None = None
@@ -176,16 +186,30 @@ class ComponentManager:
             raise ISNotStored(msg)
         return component
 
+    def get_by_id(self, id_: int) -> Any:
+        """Return the component with the input integer ID.
+
+        Raises
+        ------
+        ISNotStored
+            Raised if the ID is not stored.
+        """
+        component = self._components_by_id.get(id_)
+        if component is None:
+            msg = f"No component with id={id_} is stored"
+            raise ISNotStored(msg)
+        return component
+
     def iter_all(self) -> Iterable[Any]:
         """Return an iterator over all components."""
-        return self._components_by_uuid.values()
+        return self._components_by_id.values()
 
     def list_child_components(
         self, component: Component, component_type: Optional[Type[Component]] = None
     ) -> list[Component]:
         """Return a list of all components that this component composes."""
         return [
-            self.get_by_uuid(x)
+            self.get_by_id(x)
             for x in self._associations.list_child_components(
                 component, component_type=component_type
             )
@@ -196,7 +220,7 @@ class ComponentManager:
     ) -> list[Component]:
         """Return a list of all components that compose this component."""
         return [
-            self.get_by_uuid(x)
+            self.get_by_id(x)
             for x in self._associations.list_parent_components(
                 component, component_type=component_type
             )
@@ -250,6 +274,8 @@ class ComponentManager:
                 container.pop(i)
                 if not self._components[component_type][key]:
                     self._components[component_type].pop(key)
+                    if component.id is not None:
+                        self._components_by_id.pop(component.id)
                     self._components_by_uuid.pop(component.uuid)
                 if not self._components[component_type]:
                     self._components.pop(component_type)
@@ -259,8 +285,8 @@ class ComponentManager:
                 else:
                     child_components = []
                 self._associations.remove(component)
-                for child_uuid in child_components:
-                    child = self.get_by_uuid(child_uuid)
+                for child_id in child_components:
+                    child = self.get_by_id(child_id)
                     parent_components = self.list_parent_components(child)
                     if not parent_components:
                         self.remove(child, cascade_down=cascade_down, force=force)
@@ -299,7 +325,7 @@ class ComponentManager:
             if field == "name" and name:
                 # Name is special-cased because it is a frozen field.
                 val = name
-            elif field in ("uuid",):
+            elif field in ("id", "uuid", "legacy_uuid"):
                 continue
             else:
                 val = cur_val
@@ -315,8 +341,7 @@ class ComponentManager:
 
     def deepcopy(self, component: Component) -> Component:
         """Create a deep copy of the component."""
-        values = component.model_dump()
-        return type(component)(**values)
+        return copy.deepcopy(component)
 
     def change_uuid(self, component: Component) -> None:
         """Change the component UUID."""
@@ -352,8 +377,16 @@ class ComponentManager:
             # We could prevent the user from changing the JSON with a checksum.
             self._check_component_addition(component)
             component.check_component_addition()
+        if component.id is None:
+            component.id = self._id_manager.get_next_id()
+        elif component.id in self._components_by_id:
+            msg = f"{component.label} with id={component.id} is already stored"
+            raise ISAlreadyAttached(msg)
+        else:
+            self._id_manager.advance_past(component.id)
+
         if component.uuid in self._components_by_uuid:
-            msg = f"{component.label} with UUID={component.uuid} is already stored"
+            msg = f"{component.label} with legacy UUID={component.uuid} is already stored"
             raise ISAlreadyAttached(msg)
 
         cls = type(component)
@@ -365,6 +398,7 @@ class ComponentManager:
             self._components[cls][name] = []
 
         self._components[cls][name].append(component)
+        self._components_by_id[component.id] = component
         self._components_by_uuid[component.uuid] = component
 
         logger.debug("Added {} to the system", component.label)
@@ -375,27 +409,39 @@ class ComponentManager:
         for field in type(component).model_fields:
             val = getattr(component, field)
             if isinstance(val, Component):
-                self._handle_composed_component(val)
+                self._handle_composed_component(val, parent_label=component.label)
                 # Recurse.
                 self._check_component_addition(val)
             elif isinstance(val, list) and val and isinstance(val[0], Component):
                 for item in val:
-                    self._handle_composed_component(item)
+                    self._handle_composed_component(item, parent_label=component.label)
                     # Recurse.
                     self._check_component_addition(item)
 
-    def _handle_composed_component(self, component: Component) -> None:
+    def _handle_composed_component(
+        self, component: Component, parent_label: str | None = None
+    ) -> None:
         """Do what's needed for a composed component depending on system settings:
-        nothing, add, or raise an exception."""
-        if component.uuid in self._components_by_uuid:
+        nothing, add, or raise an exception.
+
+        Parameters
+        ----------
+        component
+            The composed (child) component.
+        parent_label
+            The label of the parent component that contains this composed component.
+            Used to produce a clearer error message.
+        """
+        if component.id is not None and component.id in self._components_by_id:
             return
 
         if self._auto_add_composed_components:
             logger.debug("Auto-add composed component {}", component.label)
             self._add(component, False)
         else:
+            parent = parent_label or component.label
             msg = (
-                f"Component {component.label} cannot be added to the system because "
+                f"Component {parent} cannot be added to the system because "
                 f"its composed component {component.label} is not already attached."
             )
             raise ISOperationNotAllowed(msg)
@@ -409,7 +455,7 @@ class ComponentManager:
 
     def raise_if_attached(self, component: Component):
         """Raise an exception if this component is attached to a system."""
-        if component.uuid in self._components_by_uuid:
+        if component.id is not None and component.id in self._components_by_id:
             msg = f"{component.label} is already attached to the system"
             raise ISAlreadyAttached(msg)
 
@@ -421,6 +467,6 @@ class ComponentManager:
         system_uuid : UUID
             The component must be attached to the system with this UUID.
         """
-        if component.uuid not in self._components_by_uuid:
+        if component.id is None or component.id not in self._components_by_id:
             msg = f"{component.label} is not attached to the system"
             raise ISNotStored(msg)

--- a/src/infrasys/component_manager.py
+++ b/src/infrasys/component_manager.py
@@ -444,7 +444,7 @@ class ComponentManager:
             The label of the parent component that contains this composed component.
             Used to produce a clearer error message.
         """
-        if component.id is not None and component.id in self._components_by_id:
+        if self.has_component(component):
             return
 
         if self._auto_add_composed_components:

--- a/src/infrasys/component_manager.py
+++ b/src/infrasys/component_manager.py
@@ -216,6 +216,7 @@ class ComponentManager:
         self, component: Component, component_type: Optional[Type[Component]] = None
     ) -> list[Component]:
         """Return a list of all components that this component composes."""
+        self.raise_if_not_attached(component)
         return [
             self.get_by_id(x)
             for x in self._associations.list_child_components(
@@ -227,6 +228,7 @@ class ComponentManager:
         self, component: Component, component_type: Optional[Type[Component]] = None
     ) -> list[Component]:
         """Return a list of all components that compose this component."""
+        self.raise_if_not_attached(component)
         return [
             self.get_by_id(x)
             for x in self._associations.list_parent_components(

--- a/src/infrasys/component_manager.py
+++ b/src/infrasys/component_manager.py
@@ -278,7 +278,7 @@ class ComponentManager:
         self._check_parent_components_for_remove(component, force)
         container = self._components[component_type][key]
         for i, comp in enumerate(container):
-            if comp.uuid == component.uuid:
+            if _component_matches(comp, component):
                 container.pop(i)
                 # Always clean up ID/UUID indexes for the removed component,
                 # regardless of whether other components remain under the same key.
@@ -480,3 +480,14 @@ class ComponentManager:
         if component.id is None or component.id not in self._components_by_id:
             msg = f"{component.label} is not attached to the system"
             raise ISNotStored(msg)
+
+
+def _component_matches(a: Component, b: Component) -> bool:
+    """Return True if two component references match the same stored component.
+
+    Prefers matching by integer ``id``; falls back to ``uuid`` when ``id`` is
+    not available on either reference.
+    """
+    if a.id is not None and b.id is not None:
+        return a.id == b.id
+    return a.uuid == b.uuid

--- a/src/infrasys/component_manager.py
+++ b/src/infrasys/component_manager.py
@@ -107,25 +107,33 @@ class ComponentManager:
             Raised if there is more than one matching component.
         """
         class_name, name_or_uuid = get_class_and_name_from_label(label)
+        if isinstance(name_or_uuid, UUID):
+            return self.get_by_uuid(name_or_uuid)
+
+        # Try name-based lookup first (handles numeric component names like "123").
+        # Only falls through to ID-based lookup when no name match is found.
+        if isinstance(name_or_uuid, str):
+            for component_type, components_by_name in self._components.items():
+                if component_type.__name__ == class_name:
+                    components = components_by_name.get(name_or_uuid)
+                    if components is not None:
+                        if len(components) > 1:
+                            msg = f"There is more than one component with {label=}."
+                            raise ISOperationNotAllowed(msg)
+                        return components[0]
+            # Name not found; try to parse as integer ID
+            try:
+                name_or_uuid = int(name_or_uuid)
+            except ValueError:
+                msg = f"No component with {label=} is stored."
+                raise ISNotStored(msg)
+
         if isinstance(name_or_uuid, int):
             component = self.get_by_id(name_or_uuid)
             if type(component).__name__ == class_name:
                 return component
             msg = f"No component with {label=} is stored."
             raise ISNotStored(msg)
-        if isinstance(name_or_uuid, UUID):
-            return self.get_by_uuid(name_or_uuid)
-
-        for component_type, components_by_name in self._components.items():
-            if component_type.__name__ == class_name:
-                components = components_by_name.get(name_or_uuid)
-                if components is None:
-                    msg = f"No component with {label=} is stored."
-                    raise ISNotStored(msg)
-                if len(components) > 1:
-                    msg = f"There is more than one component with {label=}."
-                    raise ISOperationNotAllowed(msg)
-                return components[0]
 
         msg = f"No component with {label=} is stored."
         raise ISNotStored(msg)
@@ -272,11 +280,13 @@ class ComponentManager:
         for i, comp in enumerate(container):
             if comp.uuid == component.uuid:
                 container.pop(i)
+                # Always clean up ID/UUID indexes for the removed component,
+                # regardless of whether other components remain under the same key.
+                if component.id is not None:
+                    self._components_by_id.pop(component.id, None)
+                self._components_by_uuid.pop(component.uuid, None)
                 if not self._components[component_type][key]:
                     self._components[component_type].pop(key)
-                    if component.id is not None:
-                        self._components_by_id.pop(component.id)
-                    self._components_by_uuid.pop(component.uuid)
                 if not self._components[component_type]:
                     self._components.pop(component_type)
                 logger.debug("Removed component {}", component.label)

--- a/src/infrasys/component_manager.py
+++ b/src/infrasys/component_manager.py
@@ -121,19 +121,16 @@ class ComponentManager:
                             msg = f"There is more than one component with {label=}."
                             raise ISOperationNotAllowed(msg)
                         return components[0]
-            # Name not found; try to parse as integer ID
+            # Name not found; try to parse as integer ID.
             try:
-                name_or_uuid = int(name_or_uuid)
+                component_id = int(name_or_uuid)
             except ValueError:
                 msg = f"No component with {label=} is stored."
                 raise ISNotStored(msg)
 
-        if isinstance(name_or_uuid, int):
-            component = self.get_by_id(name_or_uuid)
+            component = self.get_by_id(component_id)
             if type(component).__name__ == class_name:
                 return component
-            msg = f"No component with {label=} is stored."
-            raise ISNotStored(msg)
 
         msg = f"No component with {label=} is stored."
         raise ISNotStored(msg)
@@ -144,7 +141,10 @@ class ComponentManager:
 
     def has_component(self, component) -> bool:
         """Return True if the component is attached."""
-        return component.id in self._components_by_id if component.id is not None else False
+        if component.id is None:
+            return False
+        stored_component = self._components_by_id.get(component.id)
+        return stored_component is not None and _component_matches(stored_component, component)
 
     def iter(
         self, *component_types: Type[Component], filter_func: Callable | None = None
@@ -275,35 +275,37 @@ class ComponentManager:
             msg = f"{component.label} is not stored"
             raise ISNotStored(msg)
 
-        self._check_parent_components_for_remove(component, force)
         container = self._components[component_type][key]
-        for i, comp in enumerate(container):
-            if _component_matches(comp, component):
-                container.pop(i)
-                # Always clean up ID/UUID indexes for the removed component,
-                # regardless of whether other components remain under the same key.
-                if component.id is not None:
-                    self._components_by_id.pop(component.id, None)
-                self._components_by_uuid.pop(component.uuid, None)
-                if not self._components[component_type][key]:
-                    self._components[component_type].pop(key)
-                if not self._components[component_type]:
-                    self._components.pop(component_type)
-                logger.debug("Removed component {}", component.label)
-                if cascade_down:
-                    child_components = self._associations.list_child_components(component)
-                else:
-                    child_components = []
-                self._associations.remove(component)
-                for child_id in child_components:
-                    child = self.get_by_id(child_id)
-                    parent_components = self.list_parent_components(child)
-                    if not parent_components:
-                        self.remove(child, cascade_down=cascade_down, force=force)
-                return
-
-        msg = f"Component {component.label} is not stored"
-        raise ISNotStored(msg)
+        matches = [
+            (i, comp) for i, comp in enumerate(container) if _component_matches(comp, component)
+        ]
+        if not matches:
+            msg = f"Component {component.label} is not stored"
+            raise ISNotStored(msg)
+        matched_index, matched_component = matches[0]
+        self._check_parent_components_for_remove(matched_component, force)
+        container.pop(matched_index)
+        # Always clean up ID/UUID indexes for the removed component,
+        # regardless of whether other components remain under the same key.
+        if matched_component.id is not None:
+            self._components_by_id.pop(matched_component.id, None)
+        self._components_by_uuid.pop(matched_component.uuid, None)
+        if not self._components[component_type][key]:
+            self._components[component_type].pop(key)
+        if not self._components[component_type]:
+            self._components.pop(component_type)
+        logger.debug("Removed component {}", matched_component.label)
+        if cascade_down:
+            child_components = self._associations.list_child_components(matched_component)
+        else:
+            child_components = []
+        self._associations.remove(matched_component)
+        for child_id in child_components:
+            child = self.get_by_id(child_id)
+            parent_components = self.list_parent_components(child)
+            if not parent_components:
+                self.remove(child, cascade_down=cascade_down, force=force)
+        return
 
     def _check_parent_components_for_remove(self, component: Component, force: bool) -> None:
         parent_components = self.list_parent_components(component)
@@ -477,17 +479,13 @@ class ComponentManager:
         system_uuid : UUID
             The component must be attached to the system with this UUID.
         """
-        if component.id is None or component.id not in self._components_by_id:
+        if not self.has_component(component):
             msg = f"{component.label} is not attached to the system"
             raise ISNotStored(msg)
 
 
 def _component_matches(a: Component, b: Component) -> bool:
-    """Return True if two component references match the same stored component.
-
-    Prefers matching by integer ``id``; falls back to ``uuid`` when ``id`` is
-    not available on either reference.
-    """
-    if a.id is not None and b.id is not None:
-        return a.id == b.id
-    return a.uuid == b.uuid
+    """Return True if two component references identify the same stored component."""
+    if a.id is None or b.id is None:
+        return False
+    return a.id == b.id and a.uuid == b.uuid

--- a/src/infrasys/id_manager.py
+++ b/src/infrasys/id_manager.py
@@ -11,3 +11,8 @@ class IDManager(InfraSysBaseModel):
         next_id = self.next_id
         self.next_id += 1
         return next_id
+
+    def advance_past(self, id_: int) -> None:
+        """Advance the next available ID beyond an externally supplied ID."""
+        if id_ >= self.next_id:
+            self.next_id = id_ + 1

--- a/src/infrasys/migrations/db_migrations.py
+++ b/src/infrasys/migrations/db_migrations.py
@@ -9,7 +9,7 @@ from infrasys import (
     TIME_SERIES_ASSOCIATIONS_TABLE,
     TIME_SERIES_METADATA_TABLE,
 )
-from infrasys.time_series_metadata_store import make_features_string
+from infrasys.time_series_metadata_store import TimeSeriesMetadataStore, make_features_string
 from infrasys.utils.metadata_utils import (
     create_associations_table,
     create_key_value_store,
@@ -36,7 +36,7 @@ def metadata_store_needs_migration(conn: sqlite3.Connection, version: str | None
     cursor = conn.cursor()
     query = "SELECT 1 FROM sqlite_master WHERE type='table' AND name=? LIMIT 1"
     cursor.execute(query, (TIME_SERIES_ASSOCIATIONS_TABLE,))
-    return not cursor.fetchone() is not None
+    return cursor.fetchone() is None
 
 
 def migrate_legacy_metadata_store(conn: sqlite3.Connection) -> bool:
@@ -189,19 +189,16 @@ def migrate_legacy_metadata_store(conn: sqlite3.Connection) -> bool:
     logger.info(
         f"Inserting {len(sql_data_to_insert)} records into {TIME_SERIES_ASSOCIATIONS_TABLE}."
     )
-    cursor.executemany(
-        f"""
-        INSERT INTO `{TIME_SERIES_ASSOCIATIONS_TABLE}` (
-            time_series_uuid, time_series_type, initial_timestamp, resolution,
-            length, name, owner_uuid, owner_type, owner_category, features, units,
-            metadata_uuid
-        ) VALUES (
-            :time_series_uuid, :time_series_type, :initial_timestamp, :resolution,
-            :length, :name, :owner_uuid, :owner_type, :owner_category,
-            :features_json, :units, :metadata_uuid
-        )
-        """,
-        sql_data_to_insert,
+    metadata_store = TimeSeriesMetadataStore(conn, initialize=False)
+    metadata_store._insert_rows(  # type: ignore[attr-defined]
+        [
+            {
+                **row,
+                "features": row.pop("features_json"),
+            }
+            for row in sql_data_to_insert
+        ],
+        cursor,
     )
 
     # Dropping legacy table since it is no longer required.

--- a/src/infrasys/migrations/db_migrations.py
+++ b/src/infrasys/migrations/db_migrations.py
@@ -190,7 +190,7 @@ def migrate_legacy_metadata_store(conn: sqlite3.Connection) -> bool:
         f"Inserting {len(sql_data_to_insert)} records into {TIME_SERIES_ASSOCIATIONS_TABLE}."
     )
     metadata_store = TimeSeriesMetadataStore(conn, initialize=False)
-    metadata_store._insert_rows(  # type: ignore[attr-defined]
+    metadata_store.insert_rows(
         [
             {
                 **row,

--- a/src/infrasys/models.py
+++ b/src/infrasys/models.py
@@ -5,7 +5,8 @@ from typing import Any
 from uuid import UUID, uuid4
 
 from loguru import logger
-from pydantic import BaseModel, ConfigDict, Field, field_serializer
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
+from pydantic.json_schema import SkipJsonSchema
 
 
 def make_model_config(**kwargs: Any) -> ConfigDict:
@@ -28,19 +29,35 @@ class InfraSysBaseModel(BaseModel):
     model_config = make_model_config()
 
 
-class InfraSysBaseModelWithIdentifers(InfraSysBaseModel, abc.ABC):
-    """Base class for all Infrastructure Systems types with UUIDs"""
+class InfraSysBaseModelWithIdentifiers(InfraSysBaseModel, abc.ABC):
+    """Base class for Infrastructure Systems types with stable integer identifiers."""
 
-    uuid: UUID = Field(default_factory=uuid4, repr=False)
+    id: int | None = Field(
+        default=None,
+        ge=1,
+        repr=False,
+        validation_alias=AliasChoices("id"),
+    )
+    legacy_uuid: SkipJsonSchema[UUID] = Field(
+        default_factory=uuid4,
+        exclude=True,
+        repr=False,
+        validation_alias=AliasChoices("legacy_uuid", "uuid"),
+    )
 
-    @field_serializer("uuid")
-    def _serialize_uuid(self, _) -> str:
-        return str(self.uuid)
+    @property
+    def uuid(self) -> UUID:
+        """Return the legacy UUID for backwards-compatible API access."""
+        return self.legacy_uuid
+
+    @uuid.setter
+    def uuid(self, value: UUID) -> None:
+        self.legacy_uuid = value
 
     def assign_new_uuid(self):
-        """Generate a new UUID."""
-        self.uuid = uuid4()
-        logger.debug("Assigned new UUID for {}: {}", self.label, self.uuid)
+        """Generate a new legacy UUID."""
+        self.legacy_uuid = uuid4()
+        logger.debug("Assigned new legacy UUID for {}: {}", self.label, self.legacy_uuid)
 
     @classmethod
     def example(cls) -> "InfraSysBaseModelWithIdentifers":
@@ -58,8 +75,11 @@ class InfraSysBaseModelWithIdentifers(InfraSysBaseModel, abc.ABC):
     def label(self) -> str:
         """Provides a description of an instance."""
         class_name = self.__class__.__name__
-        name = getattr(self, "name", "") or str(self.uuid)
+        name = getattr(self, "name", "") or str(self.id or self.legacy_uuid)
         return make_label(class_name, name)
+
+
+InfraSysBaseModelWithIdentifers = InfraSysBaseModelWithIdentifiers
 
 
 def make_label(class_name: str, name: str) -> str:
@@ -67,12 +87,17 @@ def make_label(class_name: str, name: str) -> str:
     return f"{class_name}.{name}"
 
 
-def get_class_and_name_from_label(label: str) -> tuple[str, str | UUID]:
+def get_class_and_name_from_label(label: str) -> tuple[str, str | int | UUID]:
     """Return the class and name from a label.
     If the name is a stringified UUID, it will be converted to a UUID.
     """
     class_name, name = label.split(".", maxsplit=1)
-    name_or_uuid: str | UUID = name
+    name_or_uuid: str | int | UUID = name
+    try:
+        name_or_uuid = int(name)
+        return class_name, name_or_uuid
+    except ValueError:
+        pass
     try:
         name_or_uuid = UUID(name)
     except ValueError:

--- a/src/infrasys/models.py
+++ b/src/infrasys/models.py
@@ -87,17 +87,14 @@ def make_label(class_name: str, name: str) -> str:
     return f"{class_name}.{name}"
 
 
-def get_class_and_name_from_label(label: str) -> tuple[str, str | int | UUID]:
+def get_class_and_name_from_label(label: str) -> tuple[str, str | UUID]:
     """Return the class and name from a label.
     If the name is a stringified UUID, it will be converted to a UUID.
+    Numeric names are returned as strings so that callers can attempt a name-based
+    lookup first and fall back to an ID-based lookup only when the name is not found.
     """
     class_name, name = label.split(".", maxsplit=1)
-    name_or_uuid: str | int | UUID = name
-    try:
-        name_or_uuid = int(name)
-        return class_name, name_or_uuid
-    except ValueError:
-        pass
+    name_or_uuid: str | UUID = name
     try:
         name_or_uuid = UUID(name)
     except ValueError:

--- a/src/infrasys/serialization.py
+++ b/src/infrasys/serialization.py
@@ -36,14 +36,28 @@ class SerializedBaseType(SerializedTypeBase):
 
 
 class SerializedComponentReference(SerializedTypeBase):
-    """Reference information for a component serialized inside another component."""
+    """Reference information for a component serialized inside another component.
 
-    serialized_type: Literal[SerializedType.COMPOSED_COMPONENT] = SerializedType.COMPOSED_COMPONENT
-    id: int = Field(ge=1, validation_alias=AliasChoices("id"))
+    Integer IDs are the primary key. Legacy UUIDs are preserved for backward
+    compatibility during deserialization but are excluded from serialized output.
+    """
+
+    serialized_type: Literal[SerializedType.COMPOSED_COMPONENT] = (
+        SerializedType.COMPOSED_COMPONENT
+    )
+    id: int = Field(
+        ge=1,
+        validation_alias=AliasChoices("id"),
+        description="Integer ID referencing the serialized component",
+    )
     legacy_uuid: SkipJsonSchema[UUID | None] = Field(
         default=None,
         exclude=True,
         validation_alias=AliasChoices("legacy_uuid", "uuid"),
+        description=(
+            "Legacy UUID reference accepted during deserialization for backward "
+            "compatibility; never included in serialized output"
+        ),
     )
 
     @property

--- a/src/infrasys/serialization.py
+++ b/src/infrasys/serialization.py
@@ -3,7 +3,8 @@ import importlib
 from typing import Annotated, Any, Literal, Type, TypeAlias, Union
 from uuid import UUID
 
-from pydantic import Field, TypeAdapter, field_serializer
+from pydantic import AliasChoices, Field, TypeAdapter
+from pydantic.json_schema import SkipJsonSchema
 
 from infrasys.models import InfraSysBaseModel
 from infrasys.time_series_models import TimeSeriesData
@@ -35,14 +36,23 @@ class SerializedBaseType(SerializedTypeBase):
 
 
 class SerializedComponentReference(SerializedTypeBase):
-    """Reference information for a component that has been serialized as a UUID within another."""
+    """Reference information for a component serialized inside another component."""
 
     serialized_type: Literal[SerializedType.COMPOSED_COMPONENT] = SerializedType.COMPOSED_COMPONENT
-    uuid: UUID
+    id: int = Field(ge=1, validation_alias=AliasChoices("id"))
+    legacy_uuid: SkipJsonSchema[UUID | None] = Field(
+        default=None,
+        exclude=True,
+        validation_alias=AliasChoices("legacy_uuid", "uuid"),
+    )
 
-    @field_serializer("uuid")
-    def _serialize_uuid(self, _) -> str:
-        return str(self.uuid)
+    @property
+    def uuid(self) -> UUID:
+        """Return the legacy referenced component UUID for backwards-compatible callers."""
+        if self.legacy_uuid is None:
+            msg = "Serialized component reference does not contain a legacy UUID"
+            raise AttributeError(msg)
+        return self.legacy_uuid
 
 
 class SerializedQuantityType(SerializedTypeBase):

--- a/src/infrasys/supplemental_attribute_associations.py
+++ b/src/infrasys/supplemental_attribute_associations.py
@@ -178,16 +178,12 @@ class SupplementalAttributeAssociationsStore:
         rows = execute(cur, self._LIST_ASSOCIATED_COMPONENT_IDS_QUERY, params=params)
         return [x[0] for x in rows]
 
-    _LIST_ASSOCIATED_SUPPLEMENTAL_ATTRIBUTE_IDS_QUERY1 = f"""
-        SELECT attribute_id
-        FROM {TABLE_NAME}
-        WHERE component_id = ?
-    """
-    _LIST_ASSOCIATED_SUPPLEMENTAL_ATTRIBUTE_IDS_QUERY2 = f"""
-        SELECT attribute_id
-        FROM {TABLE_NAME}
-        WHERE attribute_type = ? AND component_id = ?
-    """
+    def _build_associated_attribute_ids_query(self) -> str:
+        """Return the base query for listing supplemental attribute IDs."""
+        return f"""
+            SELECT attribute_id
+            FROM {TABLE_NAME}
+        """
 
     def list_associated_supplemental_attribute_ids(
         self,
@@ -196,11 +192,12 @@ class SupplementalAttributeAssociationsStore:
     ) -> list[int]:
         """Return the supplemental attribute IDs associated with the component and attribute type."""
         assert component.id is not None
+        base = self._build_associated_attribute_ids_query()
         if attribute_type is None:
-            query = self._LIST_ASSOCIATED_SUPPLEMENTAL_ATTRIBUTE_IDS_QUERY1
+            query = f"{base} WHERE component_id = ?"
             params = (component.id,)
         else:
-            query = self._LIST_ASSOCIATED_SUPPLEMENTAL_ATTRIBUTE_IDS_QUERY2
+            query = f"{base} WHERE attribute_type = ? AND component_id = ?"
             params = (attribute_type, component.id)
         cur = self._con.cursor()
         rows = execute(cur, query, params=params)

--- a/src/infrasys/supplemental_attribute_associations.py
+++ b/src/infrasys/supplemental_attribute_associations.py
@@ -6,7 +6,7 @@ from typing import Any, Optional, Sequence
 from loguru import logger
 
 from infrasys import Component, SUPPLEMENTAL_ATTRIBUTE_ASSOCIATIONS_TABLE
-from infrasys.exceptions import ISAlreadyAttached
+from infrasys.exceptions import ISAlreadyAttached, ISOperationNotAllowed
 from infrasys.supplemental_attribute import SupplementalAttribute
 from infrasys.utils.sqlite import execute
 from infrasys.utils.metadata_utils import (
@@ -53,8 +53,12 @@ class SupplementalAttributeAssociationsStore:
             Raised if the supplemental attribute association is already stored.
         """
         con = connection or self._con
-        assert attribute.id is not None
-        assert component.id is not None
+        if attribute.id is None:
+            msg = f"{attribute.label} does not have an id assigned."
+            raise ISOperationNotAllowed(msg)
+        if component.id is None:
+            msg = f"{component.label} does not have an id assigned."
+            raise ISOperationNotAllowed(msg)
         params = (attribute.id, component.id)
         cur = con.cursor()
         res = execute(cur, self._CHECK_EXISTING_ASSOCIATION_QUERY, params=params).fetchone()
@@ -87,8 +91,12 @@ class SupplementalAttributeAssociationsStore:
         connection: sqlite3.Connection | None = None,
     ) -> bool:
         """Return True if the component and supplemental attribute have an association."""
-        assert attribute.id is not None
-        assert component.id is not None
+        if attribute.id is None:
+            msg = f"{attribute.label} does not have an id assigned."
+            raise ISOperationNotAllowed(msg)
+        if component.id is None:
+            msg = f"{component.label} does not have an id assigned."
+            raise ISOperationNotAllowed(msg)
         params = (attribute.id, component.id)
         return self._has_rows(
             self._HAS_ASSOCIATION_BY_COMPONENT_AND_ATTRIBUTE_QUERY,
@@ -105,7 +113,9 @@ class SupplementalAttributeAssociationsStore:
     ) -> bool:
         """Return true if there is at least one association matching the inputs."""
         # Note: Unlike the other has_association methods, this is not covered by an index.
-        assert attribute.id is not None
+        if attribute.id is None:
+            msg = f"{attribute.label} does not have an id assigned."
+            raise ISOperationNotAllowed(msg)
         params = (attribute.id,)
         return self._has_rows(
             self._HAS_ASSOCIATION_BY_ATTRIBUTE_QUERY,
@@ -121,7 +131,9 @@ class SupplementalAttributeAssociationsStore:
         connection: sqlite3.Connection | None = None,
     ) -> bool:
         """Return True if there is at least one association with the component."""
-        assert component.id is not None
+        if component.id is None:
+            msg = f"{component.label} does not have an id assigned."
+            raise ISOperationNotAllowed(msg)
         params = (component.id,)
         return self._has_rows(
             self._HAS_ASSOCIATION_BY_COMPONENT_QUERY,
@@ -145,7 +157,9 @@ class SupplementalAttributeAssociationsStore:
         """Return True if the component has an association with a supplemental attribute of the
         given type.
         """
-        assert component.id is not None
+        if component.id is None:
+            msg = f"{component.label} does not have an id assigned."
+            raise ISOperationNotAllowed(msg)
         params = (component.id, attribute_type)
         return self._has_rows(
             self._HAS_ASSOCIATION_BY_COMPONENT_AND_ATTRIBUTE_TYPE_QUERY,
@@ -172,7 +186,9 @@ class SupplementalAttributeAssociationsStore:
 
     def list_associated_component_ids(self, attribute: SupplementalAttribute) -> list[int]:
         """Return the component IDs associated with the attribute."""
-        assert attribute.id is not None
+        if attribute.id is None:
+            msg = f"{attribute.label} does not have an id assigned."
+            raise ISOperationNotAllowed(msg)
         params = (attribute.id,)
         cur = self._con.cursor()
         rows = execute(cur, self._LIST_ASSOCIATED_COMPONENT_IDS_QUERY, params=params)
@@ -191,7 +207,9 @@ class SupplementalAttributeAssociationsStore:
         attribute_type: Optional[str] = None,
     ) -> list[int]:
         """Return the supplemental attribute IDs associated with the component and attribute type."""
-        assert component.id is not None
+        if component.id is None:
+            msg = f"{component.label} does not have an id assigned."
+            raise ISOperationNotAllowed(msg)
         base = self._build_associated_attribute_ids_query()
         if attribute_type is None:
             query = f"{base} WHERE component_id = ?"
@@ -210,7 +228,9 @@ class SupplementalAttributeAssociationsStore:
         connection: sqlite3.Connection | None = None,
     ) -> None:
         """Remove all associations with the given attribute."""
-        assert attribute.id is not None
+        if attribute.id is None:
+            msg = f"{attribute.label} does not have an id assigned."
+            raise ISOperationNotAllowed(msg)
         where_clause = "WHERE attribute_id = ?"
         params = (attribute.id,)
         num_deleted = self._remove_associations(where_clause, params, connection=connection)
@@ -225,8 +245,12 @@ class SupplementalAttributeAssociationsStore:
         connection: sqlite3.Connection | None = None,
     ) -> None:
         """Remove the association between the attribute and component."""
-        assert attribute.id is not None
-        assert component.id is not None
+        if attribute.id is None:
+            msg = f"{attribute.label} does not have an id assigned."
+            raise ISOperationNotAllowed(msg)
+        if component.id is None:
+            msg = f"{component.label} does not have an id assigned."
+            raise ISOperationNotAllowed(msg)
         where_clause = "WHERE attribute_id = ? AND component_id = ?"
         params = (attribute.id, component.id)
         num_deleted = self._remove_associations(where_clause, params, connection=connection)

--- a/src/infrasys/supplemental_attribute_associations.py
+++ b/src/infrasys/supplemental_attribute_associations.py
@@ -2,7 +2,6 @@
 
 import sqlite3
 from typing import Any, Optional, Sequence
-from uuid import UUID
 
 from loguru import logger
 
@@ -27,15 +26,15 @@ class SupplementalAttributeAssociationsStore:
 
     _CHECK_EXISTING_ASSOCIATION_QUERY = f"""
         SELECT id FROM {TABLE_NAME}
-        WHERE attribute_uuid = ? AND component_uuid = ?
+        WHERE attribute_id = ? AND component_id = ?
         LIMIT 1
     """
     _INSERT_ASSOCIATION_QUERY = f"""
         INSERT INTO {TABLE_NAME} (
             id,
-            attribute_uuid,
+            attribute_id,
             attribute_type,
-            component_uuid,
+            component_id,
             component_type
         ) VALUES (?, ?, ?, ?, ?)
     """
@@ -54,7 +53,9 @@ class SupplementalAttributeAssociationsStore:
             Raised if the supplemental attribute association is already stored.
         """
         con = connection or self._con
-        params = (str(attribute.uuid), str(component.uuid))
+        assert attribute.id is not None
+        assert component.id is not None
+        params = (attribute.id, component.id)
         cur = con.cursor()
         res = execute(cur, self._CHECK_EXISTING_ASSOCIATION_QUERY, params=params).fetchone()
         if res:
@@ -63,18 +64,19 @@ class SupplementalAttributeAssociationsStore:
 
         row = (
             None,
-            str(attribute.uuid),
+            attribute.id,
             type(attribute).__name__,
-            str(component.uuid),
+            component.id,
             type(component).__name__,
         )
+        self._insert_parent_ids(cur, component.id, attribute.id)
         execute(cur, self._INSERT_ASSOCIATION_QUERY, params=row)
         if connection is None:
             self._con.commit()
 
     _HAS_ASSOCIATION_BY_COMPONENT_AND_ATTRIBUTE_QUERY = f"""
         SELECT id FROM {TABLE_NAME}
-        WHERE attribute_uuid = ? AND component_uuid = ?
+        WHERE attribute_id = ? AND component_id = ?
         LIMIT 1
     """
 
@@ -85,14 +87,16 @@ class SupplementalAttributeAssociationsStore:
         connection: sqlite3.Connection | None = None,
     ) -> bool:
         """Return True if the component and supplemental attribute have an association."""
-        params = (str(attribute.uuid), str(component.uuid))
+        assert attribute.id is not None
+        assert component.id is not None
+        params = (attribute.id, component.id)
         return self._has_rows(
             self._HAS_ASSOCIATION_BY_COMPONENT_AND_ATTRIBUTE_QUERY,
             params,
             connection=connection,
         )
 
-    _HAS_ASSOCIATION_BY_ATTRIBUTE_QUERY = f"SELECT id FROM {TABLE_NAME} WHERE attribute_uuid = ?"
+    _HAS_ASSOCIATION_BY_ATTRIBUTE_QUERY = f"SELECT id FROM {TABLE_NAME} WHERE attribute_id = ?"
 
     def has_association_by_attribute(
         self,
@@ -101,14 +105,15 @@ class SupplementalAttributeAssociationsStore:
     ) -> bool:
         """Return true if there is at least one association matching the inputs."""
         # Note: Unlike the other has_association methods, this is not covered by an index.
-        params = (str(attribute.uuid),)
+        assert attribute.id is not None
+        params = (attribute.id,)
         return self._has_rows(
             self._HAS_ASSOCIATION_BY_ATTRIBUTE_QUERY,
             params,
             connection=connection,
         )
 
-    _HAS_ASSOCIATION_BY_COMPONENT_QUERY = f"SELECT id FROM {TABLE_NAME} WHERE component_uuid = ?"
+    _HAS_ASSOCIATION_BY_COMPONENT_QUERY = f"SELECT id FROM {TABLE_NAME} WHERE component_id = ?"
 
     def has_association_by_component(
         self,
@@ -116,7 +121,8 @@ class SupplementalAttributeAssociationsStore:
         connection: sqlite3.Connection | None = None,
     ) -> bool:
         """Return True if there is at least one association with the component."""
-        params = (str(component.uuid),)
+        assert component.id is not None
+        params = (component.id,)
         return self._has_rows(
             self._HAS_ASSOCIATION_BY_COMPONENT_QUERY,
             params,
@@ -124,9 +130,9 @@ class SupplementalAttributeAssociationsStore:
         )
 
     _HAS_ASSOCIATION_BY_COMPONENT_AND_ATTRIBUTE_TYPE_QUERY = f"""
-        SELECT attribute_uuid
+        SELECT attribute_id
         FROM {TABLE_NAME}
-        WHERE component_uuid = ? AND attribute_type = ?
+        WHERE component_id = ? AND attribute_type = ?
         LIMIT 1
     """
 
@@ -139,7 +145,8 @@ class SupplementalAttributeAssociationsStore:
         """Return True if the component has an association with a supplemental attribute of the
         given type.
         """
-        params = (str(component.uuid), attribute_type)
+        assert component.id is not None
+        params = (component.id, attribute_type)
         return self._has_rows(
             self._HAS_ASSOCIATION_BY_COMPONENT_AND_ATTRIBUTE_TYPE_QUERY,
             params,
@@ -157,47 +164,47 @@ class SupplementalAttributeAssociationsStore:
         res = execute(cur, query, params=params).fetchone()
         return res is not None
 
-    _LIST_ASSOCIATED_COMPONENT_UUIDS_QUERY = f"""
-        SELECT component_uuid
+    _LIST_ASSOCIATED_COMPONENT_IDS_QUERY = f"""
+        SELECT component_id
         FROM {TABLE_NAME}
-        WHERE attribute_uuid = ?
+        WHERE attribute_id = ?
     """
 
-    def list_associated_component_uuids(self, attribute: SupplementalAttribute) -> list[UUID]:
-        """Return the component UUIDs associated with the attribute."""
-        params = (str(attribute.uuid),)
+    def list_associated_component_ids(self, attribute: SupplementalAttribute) -> list[int]:
+        """Return the component IDs associated with the attribute."""
+        assert attribute.id is not None
+        params = (attribute.id,)
         cur = self._con.cursor()
-        rows = execute(cur, self._LIST_ASSOCIATED_COMPONENT_UUIDS_QUERY, params=params)
-        return [UUID(x[0]) for x in rows]
+        rows = execute(cur, self._LIST_ASSOCIATED_COMPONENT_IDS_QUERY, params=params)
+        return [x[0] for x in rows]
 
-    _LIST_ASSOCIATED_SUPPLEMENTAL_ATTRIBUTE_UUIDS_QUERY1 = f"""
-        SELECT attribute_uuid
+    _LIST_ASSOCIATED_SUPPLEMENTAL_ATTRIBUTE_IDS_QUERY1 = f"""
+        SELECT attribute_id
         FROM {TABLE_NAME}
-        WHERE component_uuid = ?
+        WHERE component_id = ?
     """
-    _LIST_ASSOCIATED_SUPPLEMENTAL_ATTRIBUTE_UUIDS_QUERY2 = f"""
-        SELECT attribute_uuid
+    _LIST_ASSOCIATED_SUPPLEMENTAL_ATTRIBUTE_IDS_QUERY2 = f"""
+        SELECT attribute_id
         FROM {TABLE_NAME}
-        WHERE attribute_type = ? AND component_uuid = ?
+        WHERE attribute_type = ? AND component_id = ?
     """
 
-    def list_associated_supplemental_attribute_uuids(
+    def list_associated_supplemental_attribute_ids(
         self,
         component: Component,
         attribute_type: Optional[str] = None,
-    ) -> list[UUID]:
-        """Return the supplemental attribute UUIDs associated with the component and attribute
-        type.
-        """
+    ) -> list[int]:
+        """Return the supplemental attribute IDs associated with the component and attribute type."""
+        assert component.id is not None
         if attribute_type is None:
-            query = self._LIST_ASSOCIATED_SUPPLEMENTAL_ATTRIBUTE_UUIDS_QUERY1
-            params = (str(component.uuid),)
+            query = self._LIST_ASSOCIATED_SUPPLEMENTAL_ATTRIBUTE_IDS_QUERY1
+            params = (component.id,)
         else:
-            query = self._LIST_ASSOCIATED_SUPPLEMENTAL_ATTRIBUTE_UUIDS_QUERY2
-            params = (attribute_type, str(component.uuid))
+            query = self._LIST_ASSOCIATED_SUPPLEMENTAL_ATTRIBUTE_IDS_QUERY2
+            params = (attribute_type, component.id)
         cur = self._con.cursor()
         rows = execute(cur, query, params=params)
-        return [UUID(x[0]) for x in rows]
+        return [x[0] for x in rows]
 
     def remove_association_by_attribute(
         self,
@@ -206,8 +213,9 @@ class SupplementalAttributeAssociationsStore:
         connection: sqlite3.Connection | None = None,
     ) -> None:
         """Remove all associations with the given attribute."""
-        where_clause = "WHERE attribute_uuid = ?"
-        params = (str(attribute.uuid),)
+        assert attribute.id is not None
+        where_clause = "WHERE attribute_id = ?"
+        params = (attribute.id,)
         num_deleted = self._remove_associations(where_clause, params, connection=connection)
         if must_exist and num_deleted < 1:
             msg = f"Bug: unexpected number of deletions: {num_deleted}. Should have been >= 1."
@@ -220,8 +228,10 @@ class SupplementalAttributeAssociationsStore:
         connection: sqlite3.Connection | None = None,
     ) -> None:
         """Remove the association between the attribute and component."""
-        where_clause = "WHERE attribute_uuid = ? AND component_uuid = ?"
-        params = (str(attribute.uuid), str(component.uuid))
+        assert attribute.id is not None
+        assert component.id is not None
+        where_clause = "WHERE attribute_id = ? AND component_id = ?"
+        params = (attribute.id, component.id)
         num_deleted = self._remove_associations(where_clause, params, connection=connection)
         if num_deleted != 1:
             msg = f"Bug: unexpected number of deletions: {num_deleted}. Should have been 1."
@@ -293,7 +303,7 @@ class SupplementalAttributeAssociationsStore:
     #    #return DataFrame(_execute(associations, query))
 
     _GET_NUM_ATTRIBUTES_QUERY = f"""
-            SELECT COUNT(DISTINCT attribute_uuid) AS count
+            SELECT COUNT(DISTINCT attribute_id) AS count
             FROM {TABLE_NAME}
         """
 
@@ -303,7 +313,7 @@ class SupplementalAttributeAssociationsStore:
         return execute(cur, self._GET_NUM_ATTRIBUTES_QUERY).fetchone()[0]
 
     _GET_NUM_COMPONENTS_WITH_ATTRIBUTES_QUERY = f"""
-        SELECT COUNT(DISTINCT component_uuid) AS count
+        SELECT COUNT(DISTINCT component_id) AS count
         FROM {TABLE_NAME}
     """
 
@@ -311,3 +321,68 @@ class SupplementalAttributeAssociationsStore:
         """Return the number of components with supplemental attributes."""
         cur = self._con.cursor()
         return execute(cur, self._GET_NUM_COMPONENTS_WITH_ATTRIBUTES_QUERY).fetchone()[0]
+
+    def migrate_legacy_uuid_table(
+        self,
+        components: Sequence[Component],
+        attributes: Sequence[SupplementalAttribute],
+    ) -> None:
+        """Migrate an existing association table from UUID columns to integer ID columns."""
+        columns = _get_table_columns(self._con, TABLE_NAME)
+        if "attribute_id" in columns and "component_id" in columns:
+            return
+        if "attribute_uuid" not in columns or "component_uuid" not in columns:
+            return
+
+        component_ids = {str(component.uuid): component.id for component in components}
+        attribute_ids = {str(attribute.uuid): attribute.id for attribute in attributes}
+        if any(id_ is None for id_ in component_ids.values()):
+            msg = "Cannot migrate supplemental attribute associations before component IDs exist"
+            raise RuntimeError(msg)
+        if any(id_ is None for id_ in attribute_ids.values()):
+            msg = "Cannot migrate supplemental attribute associations before attribute IDs exist"
+            raise RuntimeError(msg)
+
+        cur = self._con.cursor()
+        rows = execute(
+            cur,
+            f"""
+            SELECT id, attribute_uuid, attribute_type, component_uuid, component_type
+            FROM {TABLE_NAME}
+            """,
+        ).fetchall()
+        execute(cur, f"ALTER TABLE {TABLE_NAME} RENAME TO {TABLE_NAME}_legacy_uuid")
+        create_supplemental_attribute_associations_table(self._con, table_name=TABLE_NAME)
+
+        migrated_rows = []
+        for row in rows:
+            row_id, attribute_uuid, attribute_type, component_uuid, component_type = row
+            attribute_id = attribute_ids.get(attribute_uuid)
+            component_id = component_ids.get(component_uuid)
+            if attribute_id is None or component_id is None:
+                msg = (
+                    "Cannot migrate supplemental attribute association with missing "
+                    f"{attribute_uuid=} or {component_uuid=}"
+                )
+                raise RuntimeError(msg)
+            migrated_rows.append(
+                (row_id, attribute_id, attribute_type, component_id, component_type)
+            )
+            self._insert_parent_ids(cur, component_id, attribute_id)
+
+        if migrated_rows:
+            cur.executemany(self._INSERT_ASSOCIATION_QUERY, migrated_rows)
+        execute(cur, f"DROP TABLE {TABLE_NAME}_legacy_uuid")
+        self._con.commit()
+
+    @staticmethod
+    def _insert_parent_ids(cur: sqlite3.Cursor, component_id: int, attribute_id: int) -> None:
+        cur.execute("INSERT OR IGNORE INTO components(id) VALUES(?)", (component_id,))
+        cur.execute(
+            "INSERT OR IGNORE INTO supplemental_attributes(id) VALUES(?)",
+            (attribute_id,),
+        )
+
+
+def _get_table_columns(con: sqlite3.Connection, table_name: str) -> set[str]:
+    return {row[1] for row in con.execute(f"PRAGMA table_info({table_name})").fetchall()}

--- a/src/infrasys/supplemental_attribute_manager.py
+++ b/src/infrasys/supplemental_attribute_manager.py
@@ -156,10 +156,18 @@ class SupplementalAttributeManager:
         raise ISNotStored(msg)
 
     def get_component_uuids_with_attribute(self, attribute: SupplementalAttribute) -> list[UUID]:
-        """Return all component UUIDs attached to the given attribute."""
-        msg = "get_component_uuids_with_attribute is deprecated; use get_component_ids_with_attribute"
-        logger.warning(msg)
-        return []
+        """Return all component UUIDs attached to the given attribute.
+
+        .. deprecated::
+            Use :meth:`get_component_ids_with_attribute` instead. This method
+            now raises :exc:`NotImplementedError` because UUID-based lookup is
+            no longer supported.
+        """
+        msg = (
+            "get_component_uuids_with_attribute is deprecated; "
+            "use get_component_ids_with_attribute instead"
+        )
+        raise NotImplementedError(msg)
 
     def get_component_ids_with_attribute(self, attribute: SupplementalAttribute) -> list[int]:
         """Return all component IDs attached to the given attribute."""

--- a/src/infrasys/supplemental_attribute_manager.py
+++ b/src/infrasys/supplemental_attribute_manager.py
@@ -2,13 +2,14 @@
 
 import sqlite3
 from contextlib import contextmanager
-from typing import Any, Callable, Generator, Iterable, Optional, Type, TypeVar, cast
+from typing import Any, Callable, Generator, Iterable, Optional, Sequence, Type, TypeVar, cast
 from uuid import UUID
 
 from loguru import logger
 
 from infrasys.component import Component
 from infrasys.exceptions import ISAlreadyAttached, ISNotStored, ISOperationNotAllowed
+from infrasys.id_manager import IDManager
 from infrasys.supplemental_attribute import SupplementalAttribute
 from infrasys.supplemental_attribute_associations import (
     SupplementalAttributeAssociationsStore,
@@ -23,6 +24,8 @@ class SupplementalAttributeManager:
     def __init__(self, con: sqlite3.Connection, initialize: bool = True, **kwargs) -> None:
         self._con = con
         self._attributes: dict[Type, dict[UUID, SupplementalAttribute]] = {}
+        self._attributes_by_id: dict[int, SupplementalAttribute] = {}
+        self._id_manager = IDManager(next_id=1)
         self._associations = SupplementalAttributeAssociationsStore(con, initialize=initialize)
         self._context: sqlite3.Connection | None = None
         self._context_new_attributes: list[SupplementalAttribute] = []
@@ -50,11 +53,17 @@ class SupplementalAttributeManager:
             attribute.check_supplemental_attribute_addition()
 
         if not already_attached:
+            if attribute.id is None:
+                attribute.id = self._id_manager.get_next_id()
+            else:
+                self._id_manager.advance_past(attribute.id)
             attr_type = type(attribute)
             if attr_type not in self._attributes:
                 self._attributes[attr_type] = {}
 
             self._attributes[attr_type][attribute.uuid] = attribute
+            assert attribute.id is not None
+            self._attributes_by_id[attribute.id] = attribute
 
         try:
             if component is not None:
@@ -110,6 +119,8 @@ class SupplementalAttributeManager:
             if attr_type not in self._attributes:
                 self._attributes[attr_type] = {}
             self._attributes[attr_type][attribute.uuid] = attribute
+            assert attribute.id is not None
+            self._attributes_by_id[attribute.id] = attribute
 
     def rollback_attribute_addition(self, attribute: SupplementalAttribute) -> None:
         """Remove an attribute from in-memory cache without modifying DB associations."""
@@ -118,6 +129,8 @@ class SupplementalAttributeManager:
         if attrs is None:
             return
         attrs.pop(attribute.uuid, None)
+        if attribute.id is not None:
+            self._attributes_by_id.pop(attribute.id, None)
         if not attrs:
             self._attributes.pop(attr_type, None)
 
@@ -144,7 +157,27 @@ class SupplementalAttributeManager:
 
     def get_component_uuids_with_attribute(self, attribute: SupplementalAttribute) -> list[UUID]:
         """Return all component UUIDs attached to the given attribute."""
-        return self._associations.list_associated_component_uuids(attribute)
+        msg = "get_component_uuids_with_attribute is deprecated; use get_component_ids_with_attribute"
+        logger.warning(msg)
+        return []
+
+    def get_component_ids_with_attribute(self, attribute: SupplementalAttribute) -> list[int]:
+        """Return all component IDs attached to the given attribute."""
+        return self._associations.list_associated_component_ids(attribute)
+
+    def get_by_id(self, id_: int) -> SupplementalAttribute:
+        """Return the supplemental attribute with the given integer ID.
+
+        Raises
+        ------
+        ISNotStored
+            Raised if the ID is not stored.
+        """
+        attr = self._attributes_by_id.get(id_)
+        if attr is None:
+            msg = f"No supplemental attribute with id={id_} is stored"
+            raise ISNotStored(msg)
+        return attr
 
     def get_attributes_with_component(
         self,
@@ -153,12 +186,12 @@ class SupplementalAttributeManager:
         filter_func: Optional[Callable[[T], bool]] = None,
     ) -> list[T]:
         attribute_type_name = None if attribute_type is None else attribute_type.__name__
-        attribute_uuids = self._associations.list_associated_supplemental_attribute_uuids(
+        attribute_ids = self._associations.list_associated_supplemental_attribute_ids(
             component, attribute_type=attribute_type_name
         )
         attributes: list[T] = []
-        for uuid in attribute_uuids:
-            attribute = cast(T, self.get_by_uuid(uuid))
+        for id_ in attribute_ids:
+            attribute = cast(T, self.get_by_id(id_))
             if filter_func is None or filter_func(attribute):
                 attributes.append(attribute)
         return attributes
@@ -214,6 +247,8 @@ class SupplementalAttributeManager:
         if self._context is not None:
             self._context_removed_attributes.append(attribute)
         self._attributes[attr_type].pop(attribute.uuid)
+        if attribute.id is not None:
+            self._attributes_by_id.pop(attribute.id, None)
         if not self._attributes[attr_type]:
             self._attributes.pop(attr_type)
         logger.debug("Removed supplemental attribute {}", attribute.label)
@@ -277,3 +312,7 @@ class SupplementalAttributeManager:
         if not self.has_attribute(attribute):
             msg = f"{attribute.label} is not attached to the system"
             raise ISNotStored(msg)
+
+    def migrate_legacy_association_schema(self, components: Sequence[Component]) -> None:
+        """Migrate stored association rows from legacy UUID columns to integer ID columns."""
+        self._associations.migrate_legacy_uuid_table(list(components), list(self.iter_all()))

--- a/src/infrasys/system.py
+++ b/src/infrasys/system.py
@@ -1019,14 +1019,15 @@ class System:
         """
         self._component_mgr.raise_if_not_attached(component)
         if self.has_time_series(component):
+            metadata_list = list(self._time_series_mgr.list_time_series_metadata(component))
             logger.warning(
                 "Removing component {} which has {} time series(s). "
                 "Time series must be removed before the component to avoid "
                 "silent CASCADE deletion in the metadata database.",
                 component.label,
-                len(list(self._time_series_mgr.list_time_series_metadata(component))),
+                len(metadata_list),
             )
-            for metadata in self._time_series_mgr.list_time_series_metadata(component):
+            for metadata in metadata_list:
                 self.remove_time_series(
                     component,
                     time_series_type=metadata.get_time_series_data_type(),

--- a/src/infrasys/system.py
+++ b/src/infrasys/system.py
@@ -1022,8 +1022,7 @@ class System:
             metadata_list = list(self._time_series_mgr.list_time_series_metadata(component))
             logger.warning(
                 "Removing component {} which has {} time series(s). "
-                "Time series must be removed before the component to avoid "
-                "silent CASCADE deletion in the metadata database.",
+                "Associated time series will be removed before the component.",
                 component.label,
                 len(metadata_list),
             )

--- a/src/infrasys/system.py
+++ b/src/infrasys/system.py
@@ -490,8 +490,12 @@ class System:
 
         if component_needs_metadata_migration(system_data["components"][0]):
             system_data["components"] = migrate_component_metadata(system_data["components"])
+        _upgrade_legacy_component_ids(system_data)
         system._deserialize_components(system_data["components"])
         system._deserialize_supplemental_attributes(system_data["supplemental_attributes"])
+        system._time_series_mgr.migrate_metadata_schema(
+            [*system._component_mgr.iter_all(), *system._supplemental_attr_mgr.iter_all()]
+        )
         logger.info("Deserialized system {}", system.label)
         return system
 
@@ -775,6 +779,10 @@ class System:
         """
         return self._component_mgr.get_by_uuid(uuid)
 
+    def get_component_by_id(self, id_: int) -> Any:
+        """Return the component with the input integer ID."""
+        return self._component_mgr.get_by_id(id_)
+
     def get_components(
         self, *component_types: Type[T], filter_func: Callable | None = None
     ) -> Iterable[T]:
@@ -822,8 +830,8 @@ class System:
     ) -> list[Component]:
         """Return all components attached to the given supplemental attribute."""
         return [
-            self._component_mgr.get_by_uuid(x)
-            for x in self._supplemental_attr_mgr.get_component_uuids_with_attribute(attribute)
+            self._component_mgr.get_by_id(x)
+            for x in self._supplemental_attr_mgr.get_component_ids_with_attribute(attribute)
         ]
 
     def get_supplemental_attributes_with_component(
@@ -853,6 +861,10 @@ class System:
     def get_supplemental_attribute_by_uuid(self, uuid: UUID) -> SupplementalAttribute:
         """Return the supplemental attribute with the given UUID."""
         return self._supplemental_attr_mgr.get_by_uuid(uuid)
+
+    def get_supplemental_attribute_by_id(self, id_: int) -> SupplementalAttribute:
+        """Return the supplemental attribute with the given integer ID."""
+        return self._supplemental_attr_mgr.get_by_id(id_)
 
     def get_supplemental_attributes(
         self,
@@ -1714,7 +1726,7 @@ class System:
     ) -> Any:
         component_type = cached_types.get_type(metadata)
         if cached_types.allowed_to_deserialize(component_type):
-            return self._components.get_by_uuid(metadata.uuid)
+            return self._components.get_by_id(metadata.id)
         return None
 
     def _deserialize_composed_list(
@@ -1726,7 +1738,7 @@ class System:
             assert isinstance(metadata, SerializedComponentReference)
             component_type = cached_types.get_type(metadata)
             if cached_types.allowed_to_deserialize(component_type):
-                deserialized_components.append(self._components.get_by_uuid(metadata.uuid))
+                deserialized_components.append(self._components.get_by_id(metadata.id))
             else:
                 return None
         return deserialized_components
@@ -1743,6 +1755,9 @@ class System:
             attr = supplemental_attribute_type(**values)
             self._supplemental_attr_mgr.add(None, attr, deserialization_in_progress=True)
             cached_types.add_deserialized_type(supplemental_attribute_type)
+        self._supplemental_attr_mgr.migrate_legacy_association_schema(
+            list(self._component_mgr.iter_all())
+        )
 
     @staticmethod
     def _make_time_series_directory(filename: Path) -> Path:
@@ -1818,6 +1833,65 @@ class System:
     def info(self):
         info = SystemInfo(system=self)
         info.render()
+
+
+def _upgrade_legacy_component_ids(system_data: dict[str, Any]) -> None:
+    """Upgrade legacy serialized component references from UUIDs to integer IDs in-place.
+
+    .. warning::
+        This function mutates *system_data* and all nested component dicts in-place.
+        Callers that need to preserve the original serialized data should pass a deep
+        copy or save a snapshot before calling this function.
+    """
+    components = system_data.get("components", [])
+    supplemental_attributes = system_data.get("supplemental_attributes", [])
+    uuid_to_id: dict[str, int] = {}
+    next_id = 1
+
+    for item in [*components, *supplemental_attributes]:
+        existing_id = item.get("id")
+        if existing_id is None:
+            existing_id = next_id
+            item["id"] = existing_id
+        next_id = max(next_id, int(existing_id) + 1)
+
+        legacy_uuid = item.get("legacy_uuid") or item.get("uuid")
+        if legacy_uuid is not None:
+            item["legacy_uuid"] = legacy_uuid
+            uuid_to_id[str(legacy_uuid)] = int(existing_id)
+            item.pop("uuid", None)
+
+    for component in components:
+        _upgrade_component_reference_ids(component, uuid_to_id)
+
+
+def _upgrade_component_reference_ids(data: Any, uuid_to_id: dict[str, int]) -> None:
+    """Upgrade legacy UUID component references to integer IDs using an explicit stack.
+
+    Mutates *data* in-place. Uses an iterative stack rather than recursion
+    to avoid hitting Python's recursion limit on deeply nested structures.
+    """
+    stack = [data]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, dict):
+            metadata = current.get(TYPE_METADATA)
+            if (
+                isinstance(metadata, dict)
+                and metadata.get("serialized_type") == SerializedType.COMPOSED_COMPONENT.value
+            ):
+                if "id" not in metadata:
+                    legacy_uuid = metadata.get("legacy_uuid") or metadata.get("uuid")
+                    if legacy_uuid is not None and str(legacy_uuid) in uuid_to_id:
+                        metadata["id"] = uuid_to_id[str(legacy_uuid)]
+                if "uuid" in metadata:
+                    metadata["legacy_uuid"] = metadata.pop("uuid")
+                continue
+
+            for value in current.values():
+                stack.append(value)
+        elif isinstance(current, list):
+            stack.extend(current)
 
 
 class SystemInfo:

--- a/src/infrasys/system.py
+++ b/src/infrasys/system.py
@@ -54,6 +54,7 @@ from .time_series_models import (
     TimeSeriesMetadata,
     TimeSeriesStorageContext,
 )
+from .utils.migrations import upgrade_legacy_component_ids
 from .utils.sqlite import backup, create_in_memory_db, restore
 from .utils.time_utils import from_iso_8601
 
@@ -490,7 +491,7 @@ class System:
 
         if component_needs_metadata_migration(system_data["components"][0]):
             system_data["components"] = migrate_component_metadata(system_data["components"])
-        _upgrade_legacy_component_ids(system_data)
+        upgrade_legacy_component_ids(system_data)
         system._deserialize_components(system_data["components"])
         system._deserialize_supplemental_attributes(system_data["supplemental_attributes"])
         system._time_series_mgr.migrate_metadata_schema(
@@ -1018,6 +1019,13 @@ class System:
         """
         self._component_mgr.raise_if_not_attached(component)
         if self.has_time_series(component):
+            logger.warning(
+                "Removing component {} which has {} time series(s). "
+                "Time series must be removed before the component to avoid "
+                "silent CASCADE deletion in the metadata database.",
+                component.label,
+                len(list(self._time_series_mgr.list_time_series_metadata(component))),
+            )
             for metadata in self._time_series_mgr.list_time_series_metadata(component):
                 self.remove_time_series(
                     component,
@@ -1833,65 +1841,6 @@ class System:
     def info(self):
         info = SystemInfo(system=self)
         info.render()
-
-
-def _upgrade_legacy_component_ids(system_data: dict[str, Any]) -> None:
-    """Upgrade legacy serialized component references from UUIDs to integer IDs in-place.
-
-    .. warning::
-        This function mutates *system_data* and all nested component dicts in-place.
-        Callers that need to preserve the original serialized data should pass a deep
-        copy or save a snapshot before calling this function.
-    """
-    components = system_data.get("components", [])
-    supplemental_attributes = system_data.get("supplemental_attributes", [])
-    uuid_to_id: dict[str, int] = {}
-    next_id = 1
-
-    for item in [*components, *supplemental_attributes]:
-        existing_id = item.get("id")
-        if existing_id is None:
-            existing_id = next_id
-            item["id"] = existing_id
-        next_id = max(next_id, int(existing_id) + 1)
-
-        legacy_uuid = item.get("legacy_uuid") or item.get("uuid")
-        if legacy_uuid is not None:
-            item["legacy_uuid"] = legacy_uuid
-            uuid_to_id[str(legacy_uuid)] = int(existing_id)
-            item.pop("uuid", None)
-
-    for component in components:
-        _upgrade_component_reference_ids(component, uuid_to_id)
-
-
-def _upgrade_component_reference_ids(data: Any, uuid_to_id: dict[str, int]) -> None:
-    """Upgrade legacy UUID component references to integer IDs using an explicit stack.
-
-    Mutates *data* in-place. Uses an iterative stack rather than recursion
-    to avoid hitting Python's recursion limit on deeply nested structures.
-    """
-    stack = [data]
-    while stack:
-        current = stack.pop()
-        if isinstance(current, dict):
-            metadata = current.get(TYPE_METADATA)
-            if (
-                isinstance(metadata, dict)
-                and metadata.get("serialized_type") == SerializedType.COMPOSED_COMPONENT.value
-            ):
-                if "id" not in metadata:
-                    legacy_uuid = metadata.get("legacy_uuid") or metadata.get("uuid")
-                    if legacy_uuid is not None and str(legacy_uuid) in uuid_to_id:
-                        metadata["id"] = uuid_to_id[str(legacy_uuid)]
-                if "uuid" in metadata:
-                    metadata["legacy_uuid"] = metadata.pop("uuid")
-                continue
-
-            for value in current.values():
-                stack.append(value)
-        elif isinstance(current, list):
-            stack.extend(current)
 
 
 class SystemInfo:

--- a/src/infrasys/time_series_manager.py
+++ b/src/infrasys/time_series_manager.py
@@ -521,11 +521,16 @@ class TimeSeriesManager:
         # Load metadata and handle storage conversion if requested
         mgr.metadata_store._load_metadata_into_memory()
         # Advance the time series ID manager so new time series get fresh IDs.
-        max_ts_id = execute(
-            mgr.metadata_store._con.cursor(),
-            f"SELECT COALESCE(MAX(time_series_id), 0) FROM {TIME_SERIES_ASSOCIATIONS_TABLE}",
-        ).fetchone()[0]
-        mgr._id_manager.advance_past(max_ts_id)
+        # Guard against legacy databases that haven't been migrated yet.
+        columns = {row[1] for row in mgr.metadata_store._con.execute(
+            f"PRAGMA table_info({TIME_SERIES_ASSOCIATIONS_TABLE})"
+        ).fetchall()}
+        if "time_series_id" in columns:
+            max_ts_id = execute(
+                mgr.metadata_store._con.cursor(),
+                f"SELECT COALESCE(MAX(time_series_id), 0) FROM {TIME_SERIES_ASSOCIATIONS_TABLE}",
+            ).fetchone()[0]
+            mgr._id_manager.advance_past(max_ts_id)
         if (
             "time_series_storage_type" in kwargs
             and _process_time_series_kwarg("time_series_storage_type", **kwargs) != ts_type

--- a/src/infrasys/time_series_manager.py
+++ b/src/infrasys/time_series_manager.py
@@ -19,6 +19,7 @@ from .arrow_storage import ArrowTimeSeriesStorage
 from .component import Component
 from .exceptions import ISInvalidParameter, ISOperationNotAllowed
 from .h5_time_series_storage import HDF5TimeSeriesStorage
+from .id_manager import IDManager
 from .in_memory_time_series_storage import InMemoryTimeSeriesStorage
 from .supplemental_attribute import SupplementalAttribute
 from .time_series_metadata_store import TimeSeriesMetadataStore
@@ -99,6 +100,7 @@ class TimeSeriesManager:
         self._read_only = _process_time_series_kwarg("time_series_read_only", **kwargs)
         self._storage = storage or self.create_new_storage(**kwargs)
         self._context: TimeSeriesStorageContext | None = None
+        self._id_manager = IDManager(next_id=1)
 
         # TODO: create parsing mechanism? CSV, CSV + JSON
 
@@ -214,6 +216,10 @@ class TimeSeriesManager:
         if not issubclass(ts_type, TimeSeriesData):
             msg = f"The first argument must be an instance of TimeSeriesData: {ts_type}"
             raise ValueError(msg)
+        if time_series.id is None:
+            time_series.id = self._id_manager.get_next_id()
+        else:
+            self._id_manager.advance_past(time_series.id)
         metadata_type = ts_type.get_time_series_metadata_type()
         metadata = metadata_type.from_data(time_series, **features)
 
@@ -519,6 +525,13 @@ class TimeSeriesManager:
         ):
             mgr.convert_storage(**kwargs)
         return mgr
+
+    def migrate_metadata_schema(
+        self,
+        owners: list[Component | SupplementalAttribute],
+    ) -> None:
+        """Migrate legacy UUID-based metadata rows to integer IDs after owners exist."""
+        self._metadata_store.migrate_legacy_uuid_table(owners)
 
     @contextmanager
     def open_time_series_store(

--- a/src/infrasys/time_series_manager.py
+++ b/src/infrasys/time_series_manager.py
@@ -530,7 +530,11 @@ class TimeSeriesManager:
         self,
         owners: list[Component | SupplementalAttribute],
     ) -> None:
-        """Migrate legacy UUID-based metadata rows to integer IDs after owners exist."""
+        """Migrate legacy UUID-based metadata rows to integer IDs after owners exist.
+
+        Delegates to :meth:`TimeSeriesMetadataStore.migrate_legacy_uuid_table`.
+        See also :func:`infrasys.utils.migrations.upgrade_legacy_component_ids`.
+        """
         self._metadata_store.migrate_legacy_uuid_table(owners)
 
     @contextmanager

--- a/src/infrasys/time_series_manager.py
+++ b/src/infrasys/time_series_manager.py
@@ -16,6 +16,7 @@ from loguru import logger
 
 from . import TIME_SERIES_ASSOCIATIONS_TABLE
 from .arrow_storage import ArrowTimeSeriesStorage
+from .utils.sqlite import execute
 from .component import Component
 from .exceptions import ISInvalidParameter, ISOperationNotAllowed
 from .h5_time_series_storage import HDF5TimeSeriesStorage
@@ -519,6 +520,12 @@ class TimeSeriesManager:
 
         # Load metadata and handle storage conversion if requested
         mgr.metadata_store._load_metadata_into_memory()
+        # Advance the time series ID manager so new time series get fresh IDs.
+        max_ts_id = execute(
+            mgr.metadata_store._con.cursor(),
+            f"SELECT COALESCE(MAX(time_series_id), 0) FROM {TIME_SERIES_ASSOCIATIONS_TABLE}",
+        ).fetchone()[0]
+        mgr._id_manager.advance_past(max_ts_id)
         if (
             "time_series_storage_type" in kwargs
             and _process_time_series_kwarg("time_series_storage_type", **kwargs) != ts_type

--- a/src/infrasys/time_series_metadata_store.py
+++ b/src/infrasys/time_series_metadata_store.py
@@ -10,6 +10,7 @@ from uuid import UUID
 
 import orjson
 
+from infrasys.id_manager import IDManager
 from infrasys.utils.sqlite import backup, execute
 
 from . import (
@@ -36,6 +37,13 @@ from .utils.metadata_utils import (
     get_window_count,
 )
 
+_OPTIONAL_INSERT_COLUMNS = (
+    "horizon",
+    "interval",
+    "window_count",
+    "scaling_factor_multiplier",
+)
+
 
 class TimeSeriesMetadataStore:
     """Stores time series metadata in a SQLite database."""
@@ -46,6 +54,9 @@ class TimeSeriesMetadataStore:
             assert create_associations_table(connection=self._con)
             create_key_value_store(connection=self._con)
         self._cache_metadata: dict[UUID, TimeSeriesMetadata] = {}
+        self._metadata_id_manager = IDManager(next_id=1)
+        self._time_series_id_manager = IDManager(next_id=1)
+        self._owner_id_manager = IDManager(next_id=1)
 
     def _load_metadata_into_memory(self):
         query = f"SELECT * FROM {TIME_SERIES_ASSOCIATIONS_TABLE}"
@@ -101,9 +112,19 @@ class TimeSeriesMetadataStore:
         if metadata.units:
             units = orjson.dumps(serialize_value(metadata.units))
 
+        if metadata.id is None:
+            metadata.id = self._metadata_id_manager.get_next_id()
+        else:
+            self._metadata_id_manager.advance_past(metadata.id)
+        if metadata.time_series_id is None:
+            metadata.time_series_id = self._time_series_id_manager.get_next_id()
+        else:
+            self._time_series_id_manager.advance_past(metadata.time_series_id)
+
         rows = [
             {
-                "time_series_uuid": str(metadata.time_series_uuid),
+                "time_series_id": metadata.time_series_id,
+                "time_series_storage_key": str(metadata.time_series_uuid),
                 "time_series_type": metadata.type,
                 "initial_timestamp": initial_time,
                 "resolution": resolution,
@@ -112,12 +133,14 @@ class TimeSeriesMetadataStore:
                 "window_count": window_count,
                 "length": metadata.length if hasattr(metadata, "length") else None,
                 "name": metadata.name,
-                "owner_uuid": str(owner.uuid),
+                "owner_id": owner.id,
+                "owner_storage_key": str(owner.uuid),
                 "owner_type": owner.__class__.__name__,
-                "owner_category": "Component",
+                "owner_category": _get_owner_category(owner),
                 "features": make_features_string(metadata.features),
                 "units": units,
-                "metadata_uuid": str(metadata.uuid),
+                "metadata_id": metadata.id,
+                "metadata_storage_key": str(metadata.uuid),
             }
             for owner in owners
         ]
@@ -155,7 +178,7 @@ class TimeSeriesMetadataStore:
         time_series_type_count = {(x[0], x[1], x[2], x[3]): x[4] for x in rows}
 
         time_series_count = execute(
-            cur, f"SELECT COUNT(DISTINCT time_series_uuid) from {TIME_SERIES_ASSOCIATIONS_TABLE}"
+            cur, f"SELECT COUNT(DISTINCT time_series_id) from {TIME_SERIES_ASSOCIATIONS_TABLE}"
         ).fetchall()[0][0]
 
         return TimeSeriesCounts(
@@ -196,7 +219,7 @@ class TimeSeriesMetadataStore:
     def has_time_series(self, time_series_uuid: UUID) -> bool:
         """Return True if there is time series matching the UUID."""
         cur = self._con.cursor()
-        query = f"SELECT 1 FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE time_series_uuid = ?"
+        query = f"SELECT 1 FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE time_series_storage_key = ?"
         row = execute(cur, query, params=(str(time_series_uuid),)).fetchone()
         return row
 
@@ -223,14 +246,14 @@ class TimeSeriesMetadataStore:
         if not params:
             return set()
         uuids = ",".join(itertools.repeat("?", len(params)))
-        query = f"SELECT DISTINCT time_series_uuid FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE time_series_uuid IN ({uuids})"
+        query = f"SELECT DISTINCT time_series_storage_key FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE time_series_storage_key IN ({uuids})"
         rows = execute(cur, query, params=params).fetchall()
         return {UUID(x[0]) for x in rows}
 
     def list_existing_time_series_uuids(self) -> set[UUID]:
         """Return the UUIDs that are present."""
         cur = self._con.cursor()
-        query = f"SELECT DISTINCT time_series_uuid FROM {TIME_SERIES_ASSOCIATIONS_TABLE}"
+        query = f"SELECT DISTINCT time_series_storage_key FROM {TIME_SERIES_ASSOCIATIONS_TABLE}"
         rows = execute(cur, query).fetchall()
         return {UUID(x[0]) for x in rows}
 
@@ -271,10 +294,10 @@ class TimeSeriesMetadataStore:
         # Use the denormalized view
         query = f"""
         SELECT
-            metadata_uuid
+            metadata_storage_key
         FROM {TIME_SERIES_ASSOCIATIONS_TABLE}
         WHERE
-            time_series_uuid = ? {limit_str}
+            time_series_storage_key = ? {limit_str}
         """
         cur = self._con.cursor()
         rows = execute(cur, query, params=params).fetchall()
@@ -314,7 +337,7 @@ class TimeSeriesMetadataStore:
         where_clause, params = self._make_where_clause(owners, name, time_series_type, **features)
 
         query = (
-            f"SELECT metadata_uuid FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE ({where_clause})"
+            f"SELECT metadata_storage_key FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE ({where_clause})"
         )
         rows = execute(cur, query, params=params).fetchall()
         matches = len(rows)
@@ -335,7 +358,7 @@ class TimeSeriesMetadataStore:
         result: list[TimeSeriesMetadata] = []
         for metadata_uuid in unique_metadata_uuids:
             query_count = (
-                f"SELECT COUNT(*) FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE metadata_uuid = ?"
+                f"SELECT COUNT(*) FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE metadata_storage_key = ?"
             )
             count_association = execute(cur, query_count, params=[str(metadata_uuid)]).fetchone()[
                 0
@@ -355,8 +378,8 @@ class TimeSeriesMetadataStore:
         con = connection or self._con
         cur = con.cursor()
 
-        query = f"DELETE FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE metadata_uuid = ?"
-        cur.execute(query, (str(metadata.uuid),))
+        query = f"DELETE FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE metadata_storage_key = ?"
+        execute(cur, query, params=(str(metadata.uuid),))
 
         if connection is None:
             con.commit()
@@ -374,16 +397,19 @@ class TimeSeriesMetadataStore:
     def _insert_rows(self, rows: list[dict], cur: sqlite3.Cursor) -> None:
         query = f"""
         INSERT INTO {TIME_SERIES_ASSOCIATIONS_TABLE} (
-            time_series_uuid, time_series_type, initial_timestamp, resolution,
-            horizon, interval, window_count, length, name, owner_uuid,
-            owner_type, owner_category, features, units, metadata_uuid
+            time_series_id, time_series_storage_key, time_series_type, initial_timestamp,
+            resolution, horizon, interval, window_count, length, name, owner_id,
+            owner_storage_key, owner_type, owner_category, features, units, metadata_id,
+            metadata_storage_key
         ) VALUES (
-            :time_series_uuid, :time_series_type, :initial_timestamp,
-            :resolution, :horizon, :interval, :window_count, :length, :name,
-            :owner_uuid, :owner_type, :owner_category, :features, :units,
-            :metadata_uuid
+            :time_series_id, :time_series_storage_key, :time_series_type,
+            :initial_timestamp, :resolution, :horizon, :interval, :window_count,
+            :length, :name, :owner_id, :owner_storage_key, :owner_type,
+            :owner_category, :features, :units, :metadata_id, :metadata_storage_key
         )
         """
+        rows = self._normalize_insert_rows(rows)
+        self._insert_parent_ids(rows, cur)
         cur.executemany(query, rows)
 
     def _make_components_str(
@@ -393,10 +419,11 @@ class TimeSeriesMetadataStore:
             msg = "At least one component must be passed."
             raise ISOperationNotAllowed(msg)
 
-        or_clause = "OR ".join((itertools.repeat("owner_uuid = ? ", len(owners))))
+        or_clause = "OR ".join((itertools.repeat("owner_id = ? ", len(owners))))
 
         for owner in owners:
-            params.append(str(owner.uuid))
+            assert owner.id is not None
+            params.append(owner.id)
 
         return f"({or_clause})"
 
@@ -431,7 +458,7 @@ class TimeSeriesMetadataStore:
         return f"({component_str} {var_str} {ts_str}) {feat_str}", params
 
     def unique_uuids_by_type(self, time_series_type: str):
-        query = f"SELECT DISTINCT time_series_uuid from {TIME_SERIES_ASSOCIATIONS_TABLE} where time_series_type = ?"
+        query = f"SELECT DISTINCT time_series_storage_key from {TIME_SERIES_ASSOCIATIONS_TABLE} where time_series_type = ?"
         params = (time_series_type,)
         uuid_strings = self.sql(query, params)
         return [UUID(ustr[0]) for ustr in uuid_strings]
@@ -465,16 +492,182 @@ class TimeSeriesMetadataStore:
         features_str = make_features_string(features)
         if features_str:
             params.append(features_str)
-        query = f"SELECT metadata_uuid FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE {where_clause} AND features = ?"
+        query = f"SELECT metadata_storage_key FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE {where_clause} AND features = ?"
         rows = execute(cur, query, params=params).fetchall()
 
         if rows:
             return [UUID(row[0]) for row in rows]
 
         where_clause, params = self._make_where_clause(owners, name, time_series_type, **features)
-        query = f"SELECT metadata_uuid FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE {where_clause}"
+        query = f"SELECT metadata_storage_key FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE {where_clause}"
         rows = execute(cur, query, params=params).fetchall()
         return [UUID(row[0]) for row in rows]
+
+    def migrate_legacy_uuid_table(self, owners: Sequence[Component | SupplementalAttribute]) -> None:
+        """Migrate legacy UUID association rows to integer ID columns."""
+        columns = _get_table_columns(self._con, TIME_SERIES_ASSOCIATIONS_TABLE)
+        if {"time_series_id", "owner_id", "metadata_id"}.issubset(columns):
+            if "owner_storage_key" in columns:
+                self._remap_owner_ids_from_storage_keys(owners)
+            return
+        if not {"time_series_uuid", "owner_uuid", "metadata_uuid"}.issubset(columns):
+            return
+
+        owner_ids = {str(owner.uuid): owner.id for owner in owners}
+        if any(id_ is None for id_ in owner_ids.values()):
+            msg = "Cannot migrate time series associations before owner IDs exist"
+            raise RuntimeError(msg)
+
+        cur = self._con.cursor()
+        rows = execute(cur, f"SELECT * FROM {TIME_SERIES_ASSOCIATIONS_TABLE}").fetchall()
+        columns_order = [row[1] for row in cur.execute(
+            f"PRAGMA table_info({TIME_SERIES_ASSOCIATIONS_TABLE})"
+        ).fetchall()]
+        row_dicts = [dict(zip(columns_order, row)) for row in rows]
+        execute(
+            cur,
+            f"ALTER TABLE {TIME_SERIES_ASSOCIATIONS_TABLE} "
+            f"RENAME TO {TIME_SERIES_ASSOCIATIONS_TABLE}_legacy_uuid",
+        )
+        create_associations_table(self._con, table_name=TIME_SERIES_ASSOCIATIONS_TABLE)
+
+        time_series_ids: dict[str, int] = {}
+        metadata_ids: dict[str, int] = {}
+        migrated = []
+        for row in row_dicts:
+            time_series_key = row["time_series_uuid"]
+            metadata_key = row["metadata_uuid"]
+            time_series_id = time_series_ids.setdefault(
+                time_series_key, self._time_series_id_manager.get_next_id()
+            )
+            metadata_id = metadata_ids.setdefault(
+                metadata_key, self._metadata_id_manager.get_next_id()
+            )
+            owner_id = owner_ids.get(row["owner_uuid"])
+            if owner_id is None:
+                msg = f"Cannot migrate time series association for owner_uuid={row['owner_uuid']}"
+                raise RuntimeError(msg)
+            migrated.append(
+                {
+                    "time_series_id": time_series_id,
+                    "time_series_storage_key": time_series_key,
+                    "time_series_type": row["time_series_type"],
+                    "initial_timestamp": row["initial_timestamp"],
+                    "resolution": row["resolution"],
+                    "horizon": row["horizon"],
+                    "interval": row["interval"],
+                    "window_count": row["window_count"],
+                    "length": row["length"],
+                    "name": row["name"],
+                    "owner_id": owner_id,
+                    "owner_storage_key": row["owner_uuid"],
+                    "owner_type": row["owner_type"],
+                    "owner_category": row["owner_category"],
+                    "features": row["features"],
+                    "units": row["units"],
+                    "metadata_id": metadata_id,
+                    "metadata_storage_key": metadata_key,
+                }
+            )
+        if migrated:
+            self._insert_rows(migrated, cur)
+        execute(cur, f"DROP TABLE {TIME_SERIES_ASSOCIATIONS_TABLE}_legacy_uuid")
+        self._con.commit()
+        self._cache_metadata.clear()
+        self._load_metadata_into_memory()
+
+    def _remap_owner_ids_from_storage_keys(
+        self, owners: Sequence[Component | SupplementalAttribute]
+    ) -> None:
+        owner_ids = {str(owner.uuid): owner.id for owner in owners}
+        cur = self._con.cursor()
+        rows = execute(
+            cur,
+            f"""
+            SELECT DISTINCT owner_storage_key
+            FROM {TIME_SERIES_ASSOCIATIONS_TABLE}
+            WHERE owner_storage_key IS NOT NULL
+            """,
+        ).fetchall()
+        for (owner_storage_key,) in rows:
+            owner_id = owner_ids.get(owner_storage_key)
+            if owner_id is None:
+                continue
+            cur.execute("INSERT OR IGNORE INTO owners(id) VALUES(?)", (owner_id,))
+            execute(
+                cur,
+                f"""
+                UPDATE {TIME_SERIES_ASSOCIATIONS_TABLE}
+                SET owner_id = ?
+                WHERE owner_storage_key = ?
+                """,
+                (owner_id, owner_storage_key),
+            )
+        self._con.commit()
+
+    @staticmethod
+    def _insert_parent_ids(rows: list[dict], cur: sqlite3.Cursor) -> None:
+        cur.executemany(
+            "INSERT OR IGNORE INTO time_series(id) VALUES(?)",
+            {(row["time_series_id"],) for row in rows},
+        )
+        cur.executemany(
+            "INSERT OR IGNORE INTO owners(id) VALUES(?)",
+            {(row["owner_id"],) for row in rows},
+        )
+        cur.executemany(
+            "INSERT OR IGNORE INTO time_series_metadata(id) VALUES(?)",
+            {(row["metadata_id"],) for row in rows},
+        )
+
+    def _normalize_insert_rows(self, rows: list[dict]) -> list[dict]:
+        normalized = []
+        owner_ids_by_storage_key: dict[str, int] = {}
+        time_series_ids_by_storage_key: dict[str, int] = {}
+        metadata_ids_by_storage_key: dict[str, int] = {}
+        for row in rows:
+            row = dict(row)
+            for column in _OPTIONAL_INSERT_COLUMNS:
+                row.setdefault(column, None)
+            if "time_series_storage_key" not in row:
+                row["time_series_storage_key"] = row.pop("time_series_uuid")
+            if "time_series_id" not in row:
+                row["time_series_id"] = self._get_or_create_id(
+                    time_series_ids_by_storage_key,
+                    row["time_series_storage_key"],
+                    self._time_series_id_manager,
+                )
+            if "metadata_storage_key" not in row:
+                row["metadata_storage_key"] = row.pop("metadata_uuid")
+            if "metadata_id" not in row:
+                row["metadata_id"] = self._get_or_create_id(
+                    metadata_ids_by_storage_key,
+                    row["metadata_storage_key"],
+                    self._metadata_id_manager,
+                )
+            if "owner_storage_key" not in row:
+                row["owner_storage_key"] = row.get("owner_uuid")
+            if "owner_id" not in row:
+                row["owner_id"] = self._get_or_create_id(
+                    owner_ids_by_storage_key,
+                    row.get("owner_storage_key") or "",
+                    self._owner_id_manager,
+                )
+            row.pop("owner_uuid", None)
+            normalized.append(row)
+        return normalized
+
+    @staticmethod
+    def _get_or_create_id(
+        ids_by_key: dict[str, int],
+        key: str,
+        id_manager: IDManager | None = None,
+    ) -> int:
+        if key not in ids_by_key:
+            ids_by_key[key] = (
+                id_manager.get_next_id() if id_manager is not None else len(ids_by_key) + 1
+            )
+        return ids_by_key[key]
 
 
 @dataclass
@@ -504,6 +697,12 @@ def _make_features_dict(features: dict[str, Any]) -> dict[str, Any]:
 
 
 def _deserialize_time_series_metadata(data: dict) -> TimeSeriesMetadata:
+    """Deserialize a time series metadata dict into a typed metadata object.
+
+    Works on a shallow copy of the input dict to avoid mutating the caller's data.
+    """
+    data = dict(data)
+    data.pop("id", None)
     time_series_type = data.pop("time_series_type")
     # NOTE: This is only relevant for compatibility with IS.jl and can be
     # removed in the future when we have tigther integration
@@ -530,7 +729,13 @@ def _deserialize_time_series_metadata(data: dict) -> TimeSeriesMetadata:
     else:
         data["features"] = {}
 
-    data["uuid"] = data.pop("metadata_uuid")
+    if "metadata_storage_key" in data:
+        data["id"] = data.pop("metadata_id")
+        data["legacy_uuid"] = data.pop("metadata_storage_key")
+    else:
+        data["legacy_uuid"] = data.pop("metadata_uuid")
+    if "time_series_storage_key" in data:
+        data["time_series_uuid"] = data.pop("time_series_storage_key")
     data["type"] = time_series_type
     metadata_instance = metadata.model_validate(
         {key: value for key, value in data.items() if key in metadata.model_fields}
@@ -542,3 +747,11 @@ def make_features_string(features: dict[str, Any]) -> str:
     """Serializes a dictionary of features into a sorted string."""
     data = [{key: value} for key, value in sorted(features.items())]
     return orjson.dumps(data).decode()
+
+
+def _get_owner_category(owner: Component | SupplementalAttribute) -> str:
+    return "Component" if isinstance(owner, Component) else "SupplementalAttribute"
+
+
+def _get_table_columns(con: sqlite3.Connection, table_name: str) -> set[str]:
+    return {row[1] for row in con.execute(f"PRAGMA table_info({table_name})").fetchall()}

--- a/src/infrasys/time_series_metadata_store.py
+++ b/src/infrasys/time_series_metadata_store.py
@@ -240,7 +240,7 @@ class TimeSeriesMetadataStore:
         cur = self._con.cursor()
         query = f"SELECT 1 FROM {TIME_SERIES_ASSOCIATIONS_TABLE} WHERE time_series_storage_key = ?"
         row = execute(cur, query, params=(str(time_series_uuid),)).fetchone()
-        return row
+        return row is not None
 
     def has_time_series_metadata(
         self,
@@ -443,7 +443,9 @@ class TimeSeriesMetadataStore:
         )
 
         for owner in owners:
-            assert owner.id is not None
+            if owner.id is None:
+                msg = f"{owner.label} does not have an id assigned."
+                raise ISOperationNotAllowed(msg)
             params.append(owner.id)
             params.append(_get_owner_category(owner))
 

--- a/src/infrasys/time_series_metadata_store.py
+++ b/src/infrasys/time_series_metadata_store.py
@@ -71,6 +71,21 @@ class TimeSeriesMetadataStore:
             )
             metadata = _deserialize_time_series_metadata(row)
             self._cache_metadata[metadata.uuid] = metadata
+        # Advance ID managers past any IDs already present in the database
+        # so that newly added metadata gets fresh IDs.
+        max_ids = cursor.execute(
+            f"""
+            SELECT
+                COALESCE(MAX(metadata_id), 0),
+                COALESCE(MAX(time_series_id), 0),
+                COALESCE(MAX(owner_id), 0)
+            FROM {TIME_SERIES_ASSOCIATIONS_TABLE}
+            """
+        ).fetchone()
+        if max_ids:
+            self._metadata_id_manager.advance_past(max_ids[0])
+            self._time_series_id_manager.advance_past(max_ids[1])
+            self._owner_id_manager.advance_past(max_ids[2])
         return
 
     def add(
@@ -144,7 +159,7 @@ class TimeSeriesMetadataStore:
             }
             for owner in owners
         ]
-        self._insert_rows(rows, cur)
+        self.insert_rows(rows, cur)
         if connection is None:
             self._con.commit()
 
@@ -394,7 +409,7 @@ class TimeSeriesMetadataStore:
         cur = self._con.cursor()
         return execute(cur, query, params=params).fetchall()
 
-    def _insert_rows(self, rows: list[dict], cur: sqlite3.Cursor) -> None:
+    def insert_rows(self, rows: list[dict], cur: sqlite3.Cursor) -> None:
         query = f"""
         INSERT INTO {TIME_SERIES_ASSOCIATIONS_TABLE} (
             time_series_id, time_series_storage_key, time_series_type, initial_timestamp,
@@ -413,17 +428,20 @@ class TimeSeriesMetadataStore:
         cur.executemany(query, rows)
 
     def _make_components_str(
-        self, params: list[str], *owners: Component | SupplementalAttribute
+        self, params: list, *owners: Component | SupplementalAttribute
     ) -> str:
         if not owners:
             msg = "At least one component must be passed."
             raise ISOperationNotAllowed(msg)
 
-        or_clause = "OR ".join((itertools.repeat("owner_id = ? ", len(owners))))
+        or_clause = "OR ".join(
+            (itertools.repeat("(owner_id = ? AND owner_category = ?) ", len(owners)))
+        )
 
         for owner in owners:
             assert owner.id is not None
             params.append(owner.id)
+            params.append(_get_owner_category(owner))
 
         return f"({or_clause})"
 
@@ -433,8 +451,8 @@ class TimeSeriesMetadataStore:
         name: str | None,
         time_series_type: str | None,
         **features: str,
-    ) -> tuple[str, list[str]]:
-        params: list[str] = []
+    ) -> tuple[str, list]:
+        params: list = []
         component_str = self._make_components_str(params, *owners)
 
         if name is None:
@@ -570,7 +588,7 @@ class TimeSeriesMetadataStore:
                 }
             )
         if migrated:
-            self._insert_rows(migrated, cur)
+            self.insert_rows(migrated, cur)
         execute(cur, f"DROP TABLE {TIME_SERIES_ASSOCIATIONS_TABLE}_legacy_uuid")
         self._con.commit()
         self._cache_metadata.clear()

--- a/src/infrasys/time_series_metadata_store.py
+++ b/src/infrasys/time_series_metadata_store.py
@@ -73,19 +73,23 @@ class TimeSeriesMetadataStore:
             self._cache_metadata[metadata.uuid] = metadata
         # Advance ID managers past any IDs already present in the database
         # so that newly added metadata gets fresh IDs.
-        max_ids = cursor.execute(
-            f"""
-            SELECT
-                COALESCE(MAX(metadata_id), 0),
-                COALESCE(MAX(time_series_id), 0),
-                COALESCE(MAX(owner_id), 0)
-            FROM {TIME_SERIES_ASSOCIATIONS_TABLE}
-            """
-        ).fetchone()
-        if max_ids:
-            self._metadata_id_manager.advance_past(max_ids[0])
-            self._time_series_id_manager.advance_past(max_ids[1])
-            self._owner_id_manager.advance_past(max_ids[2])
+        columns = {row[1] for row in cursor.execute(
+            f"PRAGMA table_info({TIME_SERIES_ASSOCIATIONS_TABLE})"
+        ).fetchall()}
+        if "metadata_id" in columns:
+            max_ids = cursor.execute(
+                f"""
+                SELECT
+                    COALESCE(MAX(metadata_id), 0),
+                    COALESCE(MAX(time_series_id), 0),
+                    COALESCE(MAX(owner_id), 0)
+                FROM {TIME_SERIES_ASSOCIATIONS_TABLE}
+                """
+            ).fetchone()
+            if max_ids:
+                self._metadata_id_manager.advance_past(max_ids[0])
+                self._time_series_id_manager.advance_past(max_ids[1])
+                self._owner_id_manager.advance_past(max_ids[2])
         return
 
     def add(
@@ -404,7 +408,7 @@ class TimeSeriesMetadataStore:
         else:
             return metadata
 
-    def sql(self, query: str, params: Sequence[str] = ()) -> list[tuple]:
+    def sql(self, query: str, params: Sequence[Any] = ()) -> list[tuple]:
         """Run a SQL query on the time series metadata table."""
         cur = self._con.cursor()
         return execute(cur, query, params=params).fetchall()

--- a/src/infrasys/time_series_models.py
+++ b/src/infrasys/time_series_models.py
@@ -368,6 +368,7 @@ class TimeSeriesMetadata(InfraSysBaseModelWithIdentifers, abc.ABC):
     """Defines common metadata for all time series."""
 
     name: str
+    time_series_id: int | None = None
     time_series_uuid: UUID
     features: dict[str, Any] = {}
     units: Optional[QuantityMetadata] = None
@@ -425,6 +426,7 @@ class SingleTimeSeriesMetadataBase(TimeSeriesMetadata, abc.ABC):
             resolution=time_series.resolution,
             initial_timestamp=time_series.initial_timestamp,
             length=time_series.length,  # type: ignore
+            time_series_id=time_series.id,
             time_series_uuid=time_series.uuid,
             features=features,
             units=units,
@@ -541,6 +543,7 @@ class DeterministicMetadata(TimeSeriesMetadata):
             interval=time_series.interval,
             horizon=time_series.horizon,
             window_count=time_series.window_count,
+            time_series_id=time_series.id,
             time_series_uuid=time_series.uuid,
             features=features,
             units=units,
@@ -757,6 +760,7 @@ class NonSequentialTimeSeriesMetadataBase(TimeSeriesMetadata, abc.ABC):
         return cls(
             name=time_series.name,
             length=time_series.length,  # type: ignore
+            time_series_id=time_series.id,
             time_series_uuid=time_series.uuid,
             features=features,
             units=units,

--- a/src/infrasys/utils/metadata_utils.py
+++ b/src/infrasys/utils/metadata_utils.py
@@ -210,7 +210,7 @@ def create_associations_table(
         "FOREIGN KEY(metadata_id) REFERENCES time_series_metadata(id) ON DELETE CASCADE",
     ]
     schema_text = ",".join(schema)
-    execute(cur, f"CREATE TABLE {table_name}({schema_text})")
+    execute(cur, f"CREATE TABLE IF NOT EXISTS {table_name}({schema_text})")
     logger.debug("Created time series associations table")
     if with_index:
         create_indexes(connection, table_name)

--- a/src/infrasys/utils/metadata_utils.py
+++ b/src/infrasys/utils/metadata_utils.py
@@ -270,7 +270,7 @@ def create_indexes(
     execute(
         cur,
         f"CREATE UNIQUE INDEX IF NOT EXISTS by_c_vn_tst_hash ON {table_name} "
-        f"(owner_id, time_series_type, name, resolution, features)",
+        f"(owner_category, owner_id, time_series_type, name, resolution, features)",
     )
     execute(
         cur,

--- a/src/infrasys/utils/metadata_utils.py
+++ b/src/infrasys/utils/metadata_utils.py
@@ -42,15 +42,23 @@ def create_supplemental_attribute_associations_table(
     bool
         True if the table exists or was created successfully.
     """
+    cur = connection.cursor()
+    execute(cur, "PRAGMA foreign_keys = ON")
+    execute(cur, "CREATE TABLE IF NOT EXISTS components(id INTEGER PRIMARY KEY)")
+    execute(
+        cur,
+        "CREATE TABLE IF NOT EXISTS supplemental_attributes(id INTEGER PRIMARY KEY)",
+    )
     schema = [
         "id INTEGER PRIMARY KEY",
-        "attribute_uuid TEXT",
+        "attribute_id INTEGER NOT NULL",
         "attribute_type TEXT",
-        "component_uuid TEXT",
+        "component_id INTEGER NOT NULL",
         "component_type TEXT",
+        "FOREIGN KEY(attribute_id) REFERENCES supplemental_attributes(id) ON DELETE CASCADE",
+        "FOREIGN KEY(component_id) REFERENCES components(id) ON DELETE CASCADE",
     ]
     schema_text = ",".join(schema)
-    cur = connection.cursor()
     execute(cur, f"CREATE TABLE IF NOT EXISTS {table_name}({schema_text})")
     logger.debug("Created supplemental attribute associations table {}", table_name)
     if with_index:
@@ -71,12 +79,12 @@ def create_supplemental_attribute_association_indexes(
     execute(
         cur,
         f"CREATE INDEX IF NOT EXISTS {table_name}_by_attribute "
-        f"ON {table_name} (attribute_uuid, component_uuid, component_type)",
+        f"ON {table_name} (attribute_id, component_id, component_type)",
     )
     execute(
         cur,
         f"CREATE INDEX IF NOT EXISTS {table_name}_by_component "
-        f"ON {table_name} (component_uuid, attribute_uuid, attribute_type)",
+        f"ON {table_name} (component_id, attribute_id, attribute_type)",
     )
     connection.commit()
 
@@ -103,15 +111,22 @@ def create_component_associations_table(
     bool
         True if the table exists or was created successfully.
     """
+    cur = connection.cursor()
+    execute(cur, "PRAGMA foreign_keys = ON")
+    execute(
+        cur,
+        "CREATE TABLE IF NOT EXISTS components(id INTEGER PRIMARY KEY)",
+    )
     schema = [
         "id INTEGER PRIMARY KEY",
-        "component_uuid TEXT",
+        "component_id INTEGER NOT NULL",
         "component_type TEXT",
-        "attached_component_uuid TEXT",
+        "attached_component_id INTEGER NOT NULL",
         "attached_component_type TEXT",
+        "FOREIGN KEY(component_id) REFERENCES components(id) ON DELETE CASCADE",
+        "FOREIGN KEY(attached_component_id) REFERENCES components(id) ON DELETE CASCADE",
     ]
     schema_text = ",".join(schema)
-    cur = connection.cursor()
     execute(cur, f"CREATE TABLE IF NOT EXISTS {table_name}({schema_text})")
     logger.debug("Created component associations table {}", table_name)
     if with_index:
@@ -131,12 +146,12 @@ def create_component_association_indexes(
     cur = connection.cursor()
     execute(
         cur,
-        f"CREATE INDEX IF NOT EXISTS {table_name}_by_component ON {table_name} (component_uuid)",
+        f"CREATE INDEX IF NOT EXISTS {table_name}_by_component ON {table_name} (component_id)",
     )
     execute(
         cur,
         f"CREATE INDEX IF NOT EXISTS {table_name}_by_attached_component "
-        f"ON {table_name} (attached_component_uuid)",
+        f"ON {table_name} (attached_component_id)",
     )
     connection.commit()
     return
@@ -164,9 +179,15 @@ def create_associations_table(
     bool
         True if the table was created successfully.
     """
+    cur = connection.cursor()
+    execute(cur, "PRAGMA foreign_keys = ON")
+    execute(cur, "CREATE TABLE IF NOT EXISTS owners(id INTEGER PRIMARY KEY)")
+    execute(cur, "CREATE TABLE IF NOT EXISTS time_series(id INTEGER PRIMARY KEY)")
+    execute(cur, "CREATE TABLE IF NOT EXISTS time_series_metadata(id INTEGER PRIMARY KEY)")
     schema = [
         "id INTEGER PRIMARY KEY",
-        "time_series_uuid TEXT NOT NULL",
+        "time_series_id INTEGER NOT NULL",
+        "time_series_storage_key TEXT NOT NULL",
         "time_series_type TEXT NOT NULL",
         "initial_timestamp TEXT",
         "resolution TEXT NULL",
@@ -175,16 +196,20 @@ def create_associations_table(
         "window_count INTEGER",
         "length INTEGER",
         "name TEXT NOT NULL",
-        "owner_uuid TEXT NOT NULL",
+        "owner_id INTEGER NOT NULL",
+        "owner_storage_key TEXT",
         "owner_type TEXT NOT NULL",
         "owner_category TEXT NOT NULL",
         "features TEXT NOT NULL",
         "scaling_factor_multiplier TEXT NULL",
-        "metadata_uuid TEXT NOT NULL",
+        "metadata_id INTEGER NOT NULL",
+        "metadata_storage_key TEXT NOT NULL",
         "units TEXT NULL",
+        "FOREIGN KEY(time_series_id) REFERENCES time_series(id) ON DELETE CASCADE",
+        "FOREIGN KEY(owner_id) REFERENCES owners(id) ON DELETE CASCADE",
+        "FOREIGN KEY(metadata_id) REFERENCES time_series_metadata(id) ON DELETE CASCADE",
     ]
     schema_text = ",".join(schema)
-    cur = connection.cursor()
     execute(cur, f"CREATE TABLE {table_name}({schema_text})")
     logger.debug("Created time series associations table")
     if with_index:
@@ -245,11 +270,15 @@ def create_indexes(
     execute(
         cur,
         f"CREATE UNIQUE INDEX IF NOT EXISTS by_c_vn_tst_hash ON {table_name} "
-        f"(owner_uuid, time_series_type, name, resolution, features)",
+        f"(owner_id, time_series_type, name, resolution, features)",
     )
     execute(
         cur,
-        f"CREATE INDEX IF NOT EXISTS by_ts_uuid ON {table_name} (time_series_uuid)",
+        f"CREATE INDEX IF NOT EXISTS by_ts_id ON {table_name} (time_series_id)",
+    )
+    execute(
+        cur,
+        f"CREATE INDEX IF NOT EXISTS by_ts_storage_key ON {table_name} (time_series_storage_key)",
     )
     return
 

--- a/src/infrasys/utils/migrations.py
+++ b/src/infrasys/utils/migrations.py
@@ -1,0 +1,64 @@
+"""Migration functions for legacy UUID-based data to integer IDs."""
+
+from typing import Any
+
+from infrasys.serialization import TYPE_METADATA, SerializedType
+
+
+def upgrade_legacy_component_ids(system_data: dict[str, Any]) -> None:
+    """Upgrade legacy serialized component references from UUIDs to integer IDs in-place.
+
+    .. warning::
+        This function mutates *system_data* and all nested component dicts in-place.
+        Callers that need to preserve the original serialized data should pass a deep
+        copy or save a snapshot before calling this function.
+    """
+    components = system_data.get("components", [])
+    supplemental_attributes = system_data.get("supplemental_attributes", [])
+    uuid_to_id: dict[str, int] = {}
+    next_id = 1
+
+    for item in [*components, *supplemental_attributes]:
+        existing_id = item.get("id")
+        if existing_id is None:
+            existing_id = next_id
+            item["id"] = existing_id
+        next_id = max(next_id, int(existing_id) + 1)
+
+        legacy_uuid = item.get("legacy_uuid") or item.get("uuid")
+        if legacy_uuid is not None:
+            item["legacy_uuid"] = legacy_uuid
+            uuid_to_id[str(legacy_uuid)] = int(existing_id)
+            item.pop("uuid", None)
+
+    for component in components:
+        _upgrade_component_reference_ids(component, uuid_to_id)
+
+
+def _upgrade_component_reference_ids(data: Any, uuid_to_id: dict[str, int]) -> None:
+    """Upgrade legacy UUID component references to integer IDs using an explicit stack.
+
+    Mutates *data* in-place. Uses an iterative stack rather than recursion
+    to avoid hitting Python's recursion limit on deeply nested structures.
+    """
+    stack = [data]
+    while stack:
+        current = stack.pop()
+        if isinstance(current, dict):
+            metadata = current.get(TYPE_METADATA)
+            if (
+                isinstance(metadata, dict)
+                and metadata.get("serialized_type") == SerializedType.COMPOSED_COMPONENT.value
+            ):
+                if "id" not in metadata:
+                    legacy_uuid = metadata.get("legacy_uuid") or metadata.get("uuid")
+                    if legacy_uuid is not None and str(legacy_uuid) in uuid_to_id:
+                        metadata["id"] = uuid_to_id[str(legacy_uuid)]
+                if "uuid" in metadata:
+                    metadata["legacy_uuid"] = metadata.pop("uuid")
+                continue
+
+            for value in current.values():
+                stack.append(value)
+        elif isinstance(current, list):
+            stack.extend(current)

--- a/tests/test_deterministic_time_series.py
+++ b/tests/test_deterministic_time_series.py
@@ -263,3 +263,97 @@ def test_deserialize_metadata_preserves_all_features() -> None:
     }
     metadata = _deserialize_time_series_metadata(metadata_dict)
     assert metadata.features == features
+
+
+def test_migrate_legacy_uuid_table():
+    """Test that migrate_legacy_uuid_table converts UUID-based associations to integer IDs."""
+    import sqlite3
+    from infrasys import Component
+    from infrasys.id_manager import IDManager
+    from infrasys.time_series_metadata_store import _get_owner_category
+
+    # Create a legacy UUID-based table manually
+    con = create_in_memory_db()
+    legacy_schema = [
+        "id INTEGER PRIMARY KEY",
+        "time_series_uuid TEXT NOT NULL",
+        "time_series_type TEXT NOT NULL",
+        "initial_timestamp TEXT",
+        "resolution TEXT NULL",
+        "horizon TEXT",
+        "interval TEXT",
+        "window_count INTEGER",
+        "length INTEGER",
+        "name TEXT NOT NULL",
+        "owner_uuid TEXT NOT NULL",
+        "owner_type TEXT NOT NULL",
+        "owner_category TEXT NOT NULL",
+        "features TEXT NOT NULL",
+        "scaling_factor_multiplier TEXT NULL",
+        "metadata_uuid TEXT NOT NULL",
+        "units TEXT NULL",
+    ]
+
+    class _FakeComponent(Component):
+        name: str
+
+    owner = _FakeComponent(name="test-owner")
+    owner.id = 42
+    owner.legacy_uuid = uuid.UUID("a1b2c3d4-0000-0000-0000-000000000001")
+
+    ts_uuid = str(uuid.uuid4())
+    metadata_uuid = str(uuid.uuid4())
+
+    con.execute(f"CREATE TABLE time_series_associations({','.join(legacy_schema)})")
+    con.execute(
+        "INSERT INTO time_series_associations VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        (
+            None, ts_uuid, "SingleTimeSeries",
+            datetime(2020, 1, 1).isoformat(), "PT1H",
+            None, None, None, 100, "active_power",
+            str(owner.uuid), "_FakeComponent",
+            _get_owner_category(owner), "[]",
+            None, metadata_uuid, None,
+        ),
+    )
+    con.commit()
+
+    store = TimeSeriesMetadataStore(con, initialize=False)
+    store.migrate_legacy_uuid_table([owner])
+
+    # After migration: verify the new columns exist and data is migrated
+    cur = con.cursor()
+    columns = {row[1] for row in cur.execute("PRAGMA table_info(time_series_associations)")}
+    assert "time_series_id" in columns
+    assert "owner_id" in columns
+    assert "metadata_id" in columns
+    assert "time_series_storage_key" in columns
+    assert "owner_storage_key" in columns
+    assert "metadata_storage_key" in columns
+    assert "time_series_uuid" not in columns  # old column dropped
+
+    rows = cur.execute("SELECT * FROM time_series_associations").fetchall()
+    assert len(rows) == 1
+
+    # Verify the cache loaded data correctly
+    metadata_list = store.list_metadata_with_time_series_uuid(uuid.UUID(ts_uuid))
+    assert len(metadata_list) == 1
+
+
+def test_get_owner_category():
+    """Test _get_owner_category returns correct category."""
+    from infrasys import Component
+    from infrasys.supplemental_attribute import SupplementalAttribute
+    from infrasys.time_series_metadata_store import _get_owner_category
+
+    class _FakeComponent(Component):
+        name: str
+
+    class _FakeAttr(SupplementalAttribute):
+        pass
+
+    comp = _FakeComponent(name="test")
+    attr = _FakeAttr()
+
+    assert _get_owner_category(comp) == "Component"
+    assert _get_owner_category(attr) == "SupplementalAttribute"

--- a/tests/test_deterministic_time_series.py
+++ b/tests/test_deterministic_time_series.py
@@ -227,7 +227,7 @@ def test_deterministic_single_time_series_backwards_compatibility(tmp_path: Any)
         }
     ]
 
-    metadata_store._insert_rows(rows, cursor)  # type: ignore[arg-type]
+    metadata_store.insert_rows(rows, cursor)  # type: ignore[arg-type]
     conn.commit()
 
     metadata_store._load_metadata_into_memory()  # type: ignore[misc]

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -91,9 +91,45 @@ def test_serialization(tmp_path):
     assert len(components2) == num_components
 
     for component in components:
-        component2 = system2.get_component_by_uuid(component.uuid)
+        component2 = system2.get_component_by_id(component.id)
         for key, val in component.__dict__.items():
-            assert getattr(component2, key) == val
+            if key == "legacy_uuid":
+                continue
+            if isinstance(val, Component):
+                assert getattr(component2, key).id == val.id
+            elif isinstance(val, list) and val and isinstance(val[0], Component):
+                assert [x.id for x in getattr(component2, key)] == [x.id for x in val]
+            else:
+                assert getattr(component2, key) == val
+
+
+def test_component_serialization_uses_integer_ids(tmp_path):
+    system = SimpleSystem(name="test-system", auto_add_composed_components=True)
+    gen = SimpleGenerator.example()
+    system.add_component(gen)
+
+    filename = tmp_path / "system.json"
+    system.to_json(filename, overwrite=True)
+    data = orjson.loads(filename.read_bytes())
+
+    components = data["components"]
+    assert all(isinstance(component["id"], int) for component in components)
+    assert all("uuid" not in component for component in components)
+    assert all("legacy_uuid" not in component for component in components)
+
+    serialized_gen = next(
+        component
+        for component in components
+        if component["__metadata__"]["type"] == SimpleGenerator.__name__
+    )
+    bus_reference = serialized_gen["bus"]["__metadata__"]
+    assert isinstance(bus_reference["id"], int)
+    assert "uuid" not in bus_reference
+
+    system2 = SimpleSystem.from_json(filename)
+    gen2 = system2.get_component_by_id(gen.id)
+    assert gen2.name == gen.name
+    assert gen2.bus.id == gen.bus.id
 
 
 @pytest.mark.parametrize("time_series_storage_type", TS_STORAGE_OPTIONS)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -537,3 +537,64 @@ def test_convert_chronify_storage_permanent(tmp_path):
         permanent=True,
     )
     assert (tmp_path / "time_series_data.db").exists()
+
+
+def test_upgrade_legacy_component_ids_migration():
+    """Test that upgrade_legacy_component_ids correctly upgrades a legacy UUID-based JSON."""
+    from infrasys.utils.migrations import upgrade_legacy_component_ids
+
+    # Simulate data after migrate_component_metadata has flattened __metadata__
+    # (modern flat format: serialized_type at top level of metadata)
+    system_data = {
+        "components": [
+            {
+                "uuid": "a1b2c3d4-0000-0000-0000-000000000001",
+                "name": "bus1",
+                "voltage": 1.1,
+                "__metadata__": {
+                    "module": "tests.models.simple_system",
+                    "type": "SimpleBus",
+                    "serialized_type": "base",
+                },
+            },
+            {
+                "uuid": "a1b2c3d4-0000-0000-0000-000000000002",
+                "name": "gen1",
+                "active_power": 1.0,
+                "__metadata__": {
+                    "module": "tests.models.simple_system",
+                    "type": "SimpleGenerator",
+                    "serialized_type": "base",
+                },
+                "bus": {
+                    "__metadata__": {
+                        "module": "tests.models.simple_system",
+                        "type": "SimpleBus",
+                        "serialized_type": "composed_component",
+                        "uuid": "a1b2c3d4-0000-0000-0000-000000000001",
+                    }
+                },
+            },
+        ],
+        "supplemental_attributes": [],
+    }
+
+    upgrade_legacy_component_ids(system_data)
+
+    # All components should have integer IDs
+    components = system_data["components"]
+    assert all(isinstance(c["id"], int) for c in components)
+    assert components[0]["id"] == 1
+    assert components[1]["id"] == 2
+
+    # UUID field should be replaced by legacy_uuid
+    assert "uuid" not in components[0]
+    assert components[0]["legacy_uuid"] == "a1b2c3d4-0000-0000-0000-000000000001"
+    assert "uuid" not in components[1]
+    assert components[1]["legacy_uuid"] == "a1b2c3d4-0000-0000-0000-000000000002"
+
+    # Composed component reference should have integer ID instead of UUID
+    bus_metadata = components[1]["bus"]["__metadata__"]
+    assert bus_metadata["id"] == 1
+    assert "uuid" not in bus_metadata
+    assert bus_metadata["legacy_uuid"] == "a1b2c3d4-0000-0000-0000-000000000001"

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -539,6 +539,47 @@ def test_convert_chronify_storage_permanent(tmp_path):
     assert (tmp_path / "time_series_data.db").exists()
 
 
+def test_serialized_component_reference_uuid_property_raises():
+    """Test that SerializedComponentReference.uuid raises when legacy_uuid is None."""
+    from infrasys.serialization import SerializedComponentReference
+
+    ref = SerializedComponentReference(id=1, module="test", type="TestType")
+    with pytest.raises(AttributeError, match="does not contain a legacy UUID"):
+        _ = ref.uuid  # noqa
+
+
+def test_serialized_component_reference_uuid_property_returns_value():
+    """Test that SerializedComponentReference.uuid returns the legacy UUID."""
+    from uuid import UUID
+    from infrasys.serialization import SerializedComponentReference
+
+    uuid_val = UUID("a1b2c3d4-0000-0000-0000-000000000001")
+    ref = SerializedComponentReference(id=1, legacy_uuid=uuid_val, module="test", type="TestType")
+    assert ref.uuid == uuid_val
+
+
+def test_get_class_and_name_from_label_with_uuid():
+    """Test that get_class_and_name_from_label parses UUID labels correctly."""
+    from infrasys.models import get_class_and_name_from_label
+    from uuid import UUID
+
+    uuid_str = "a1b2c3d4-0000-0000-0000-000000000001"
+    class_name, name = get_class_and_name_from_label(f"SimpleBus.{uuid_str}")
+    assert class_name == "SimpleBus"
+    assert isinstance(name, UUID)
+    assert str(name) == uuid_str
+
+
+def test_get_class_and_name_from_label_with_unknown_string():
+    """Test that get_class_and_name_from_label falls back to string for unknown formats."""
+    from infrasys.models import get_class_and_name_from_label
+
+    class_name, name = get_class_and_name_from_label("Type.my-component")
+    assert class_name == "Type"
+    assert isinstance(name, str)
+    assert name == "my-component"
+
+
 def test_upgrade_legacy_component_ids_migration():
     """Test that upgrade_legacy_component_ids correctly upgrades a legacy UUID-based JSON."""
     from infrasys.utils.migrations import upgrade_legacy_component_ids

--- a/tests/test_supplemental_attributes.py
+++ b/tests/test_supplemental_attributes.py
@@ -338,3 +338,165 @@ def test_supplemental_attribute_manager_raise_if_attached():
 
     with pytest.raises(ISAlreadyAttached, match="already attached"):
         system._supplemental_attr_mgr.raise_if_attached(attr1)
+
+
+def test_list_associated_component_ids():
+    """Test list_associated_component_ids returns correct component IDs."""
+    bus = SimpleBus(name="test-bus", voltage=1.1)
+    gen = SimpleGenerator(name="gen1", active_power=1.0, rating=1.0, bus=bus, available=True)
+    attr1 = GeographicInfo.example()
+    system = SimpleSystem(auto_add_composed_components=True)
+    system.add_component(gen)
+    system.add_supplemental_attribute(bus, attr1)
+    system.add_supplemental_attribute(gen, attr1)
+
+    ids = system._supplemental_attr_mgr._associations.list_associated_component_ids(attr1)
+    assert len(ids) == 2
+    assert bus.id in ids
+    assert gen.id in ids
+
+
+def test_list_associated_supplemental_attribute_ids_with_type_filter():
+    """Test list_associated_supplemental_attribute_ids with attribute_type filter."""
+    bus = SimpleBus(name="test-bus", voltage=1.1)
+    gen = SimpleGenerator(name="gen1", active_power=1.0, rating=1.0, bus=bus, available=True)
+    attr1 = GeographicInfo.example()
+    attr2 = Attribute(energy=Energy(10.0, "kWh"))
+    system = SimpleSystem(auto_add_composed_components=True)
+    system.add_component(gen)
+    system.add_supplemental_attribute(bus, attr1)
+    system.add_supplemental_attribute(bus, attr2)
+
+    assoc = system._supplemental_attr_mgr._associations
+    # Without type filter — both attributes
+    ids = assoc.list_associated_supplemental_attribute_ids(bus)
+    assert len(ids) == 2
+    assert attr1.id in ids
+    assert attr2.id in ids
+
+    # With type filter — only GeographicInfo
+    ids = assoc.list_associated_supplemental_attribute_ids(bus, attribute_type="GeographicInfo")
+    assert ids == [attr1.id]
+
+
+def test_get_supplemental_attribute_counts():
+    """Test get_num_attributes and get_num_components_with_attributes."""
+    bus = SimpleBus(name="bus1", voltage=1.1)
+    bus2 = SimpleBus(name="bus2", voltage=1.1)
+    gen = SimpleGenerator(name="gen1", active_power=1.0, rating=1.0, bus=bus, available=True)
+    attr1 = GeographicInfo.example()
+    system = SimpleSystem(auto_add_composed_components=True)
+    system.add_component(gen)
+    system.add_component(bus2)
+    system.add_supplemental_attribute(bus, attr1)
+    system.add_supplemental_attribute(bus2, attr1)
+
+    assert system.get_num_supplemental_attributes() == 1
+    assert system.get_num_components_with_supplemental_attributes() == 2
+
+
+def test_supplemental_attribute_by_id():
+    """Test get_supplemental_attribute_by_id."""
+    bus = SimpleBus(name="test-bus", voltage=1.1)
+    gen = SimpleGenerator(name="gen1", active_power=1.0, rating=1.0, bus=bus, available=True)
+    attr1 = GeographicInfo.example()
+    system = SimpleSystem(auto_add_composed_components=True)
+    system.add_component(gen)
+    system.add_supplemental_attribute(bus, attr1)
+    assert attr1.id is not None
+    assert system.get_supplemental_attribute_by_id(attr1.id) is attr1
+
+
+def test_migrate_supplemental_attribute_associations():
+    """Test that migrate_legacy_uuid_table converts UUID-based associations to integer IDs."""
+    import uuid as uuid_mod
+    from infrasys.utils.sqlite import create_in_memory_db, execute
+
+    con = create_in_memory_db()
+
+    # Create a legacy UUID-based table
+    legacy_schema = [
+        "id INTEGER PRIMARY KEY",
+        "attribute_uuid TEXT NOT NULL",
+        "attribute_type TEXT NOT NULL",
+        "component_uuid TEXT NOT NULL",
+        "component_type TEXT NOT NULL",
+    ]
+    table = "supplemental_attribute_associations"
+    con.execute(f"CREATE TABLE {table}({','.join(legacy_schema)})")
+    con.commit()
+
+    # Insert a legacy association
+    comp_uuid = str(uuid_mod.uuid4())
+    attr_uuid = str(uuid_mod.uuid4())
+    con.execute(
+        f"INSERT INTO {table} VALUES(?,?,?,?,?)",
+        (None, attr_uuid, "GeographicInfo", comp_uuid, "SimpleBus"),
+    )
+    con.commit()
+
+    # Create components and attributes with IDs
+    bus = SimpleBus(name="test-bus", voltage=1.1)
+    bus.id = 42
+    bus.legacy_uuid = uuid_mod.UUID(comp_uuid)
+    attr1 = GeographicInfo.example()
+    attr1.id = 99
+    attr1.legacy_uuid = uuid_mod.UUID(attr_uuid)
+
+    from infrasys.supplemental_attribute_associations import SupplementalAttributeAssociationsStore
+    store = SupplementalAttributeAssociationsStore(con, initialize=False)
+    store.migrate_legacy_uuid_table(components=[bus], attributes=[attr1])
+
+    # Verify migration succeeded
+    columns = {row[1] for row in con.execute(f"PRAGMA table_info({table})")}
+    assert "attribute_id" in columns
+    assert "component_id" in columns
+    assert "attribute_uuid" not in columns
+
+    rows = con.execute(f"SELECT * FROM {table}").fetchall()
+    assert len(rows) == 1
+    assert rows[0][1] == 99  # attribute_id
+    assert rows[0][3] == 42  # component_id
+
+
+def test_normalize_insert_rows():
+    """Test _normalize_insert_rows converts legacy UUID fields to integer IDs."""
+    import uuid as uuid_mod
+    from infrasys.time_series_metadata_store import TimeSeriesMetadataStore
+    from infrasys.utils.sqlite import create_in_memory_db
+    store = TimeSeriesMetadataStore(create_in_memory_db())
+
+    ts_uuid = str(uuid_mod.uuid4())
+    md_uuid = str(uuid_mod.uuid4())
+    rows = [
+        {
+            "time_series_uuid": ts_uuid,
+            "time_series_type": "SingleTimeSeries",
+            "initial_timestamp": datetime(2020, 1, 1),
+            "resolution": "PT1H",
+            "horizon": None,
+            "interval": None,
+            "window_count": None,
+            "length": 100,
+            "name": "active_power",
+            "owner_uuid": str(uuid_mod.uuid4()),
+            "owner_type": "SimpleGenerator",
+            "owner_category": "Component",
+            "features": "[]",
+            "units": None,
+            "metadata_uuid": md_uuid,
+        },
+    ]
+    normalized = store._normalize_insert_rows(rows)
+    assert len(normalized) == 1
+    row = normalized[0]
+    # UUID fields should be renamed to storage_key variants
+    assert "time_series_uuid" not in row
+    assert row["time_series_storage_key"] == ts_uuid
+    assert "metadata_uuid" not in row
+    assert row["metadata_storage_key"] == md_uuid
+    assert "owner_uuid" not in row
+    # Integer IDs should be auto-generated
+    assert isinstance(row["time_series_id"], int)
+    assert isinstance(row["metadata_id"], int)
+    assert isinstance(row["owner_id"], int)

--- a/tests/test_supplemental_attributes.py
+++ b/tests/test_supplemental_attributes.py
@@ -45,8 +45,8 @@ def test_supplemental_attribute_manager(tmp_path):
 
     def check_attrs(attrs):
         assert len(attrs) == 2
-        assert attrs[0] == attr1 or attrs[0] == attr2
-        assert attrs[1] == attr1 or attrs[1] == attr2
+        coordinates = {tuple(x.geo_json["geometry"]["coordinates"]) for x in attrs}
+        assert coordinates == {(125.6, 10.1), (1.0, 2.0)}
 
     for attr_type in (GeographicInfo, SupplementalAttribute):
         attrs = list(system.get_supplemental_attributes(attr_type))

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1075,6 +1075,29 @@ def test_rejects_foreign_component_with_colliding_system_local_id():
     assert system.get_component_by_uuid(local_gen.uuid) is local_gen
 
 
+def test_rejects_foreign_composed_component_with_colliding_system_local_id():
+    system = SimpleSystem()
+    local_bus = SimpleBus(name="bus", voltage=1.1)
+    system.add_component(local_bus)
+
+    foreign_system = SimpleSystem()
+    foreign_bus = SimpleBus(name="bus", voltage=1.1)
+    foreign_system.add_component(foreign_bus)
+
+    assert foreign_bus.id == local_bus.id
+    assert foreign_bus.uuid != local_bus.uuid
+
+    gen = SimpleGenerator(
+        name="gen",
+        active_power=1.0,
+        rating=1.0,
+        bus=foreign_bus,
+        available=True,
+    )
+    with pytest.raises(ISOperationNotAllowed):
+        system.add_component(gen)
+
+
 def test_get_by_label_with_integer_id():
     """Test that get_by_label resolves integer ID-based labels."""
     system = SimpleSystem(auto_add_composed_components=True)

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1046,7 +1046,7 @@ def test_remove_component_cleans_up_indexes():
 def test_rejects_foreign_component_with_colliding_system_local_id():
     """Components from another system are not attached even if system-local IDs collide."""
 
-    def make_system() -> tuple[SimpleSystem, SimpleGenerator]:
+    def make_system() -> tuple[SimpleSystem, SimpleGenerator, SimpleBus]:
         bus = SimpleBus(name="bus", voltage=1.1)
         gen = SimpleGenerator(
             name="gen",
@@ -1057,22 +1057,30 @@ def test_rejects_foreign_component_with_colliding_system_local_id():
         )
         system = SimpleSystem(auto_add_composed_components=True)
         system.add_component(gen)
-        return system, gen
+        return system, gen, bus
 
-    _, foreign_gen = make_system()
-    system, local_gen = make_system()
+    _, foreign_gen, foreign_bus = make_system()
+    system, local_gen, local_bus = make_system()
 
     assert foreign_gen.id is not None
     assert local_gen.id is not None
     assert foreign_gen.id == local_gen.id
     assert foreign_gen.uuid != local_gen.uuid
+    assert foreign_bus.id == local_bus.id
+    assert foreign_bus.uuid != local_bus.uuid
     assert not system.has_component(foreign_gen)
 
     with pytest.raises(ISNotStored):
         system.remove_component(foreign_gen, cascade_down=False)
+    with pytest.raises(ISNotStored):
+        system.list_child_components(foreign_gen)
+    with pytest.raises(ISNotStored):
+        system.list_parent_components(foreign_bus)
 
     assert system.get_component_by_id(local_gen.id) is local_gen
     assert system.get_component_by_uuid(local_gen.uuid) is local_gen
+    assert system.list_child_components(local_gen) == [local_bus]
+    assert system.list_parent_components(local_bus) == [local_gen]
 
 
 def test_rejects_foreign_composed_component_with_colliding_system_local_id():

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -592,7 +592,8 @@ def test_system_to_dict():
 
     component_dict: list[dict] = list(system.to_records(SimpleGenerator))
     assert len(component_dict) == 3  # 3 generators
-    assert component_dict[0].get("uuid") is not None
+    assert component_dict[0].get("id") is not None
+    assert component_dict[0].get("uuid") is None
     assert component_dict[0]["bus"] == gen1.bus.label
 
     exclude_first_level_fields = {"name": True, "available": True}
@@ -632,17 +633,18 @@ def test_time_series_metadata_sql():
     system.add_time_series(ts2, gen2)
     rows = system.time_series.metadata_store.sql(
         f"""
-        SELECT owner_type, time_series_type, owner_uuid, time_series_uuid
+        SELECT owner_type, time_series_type, owner_id, time_series_id, time_series_storage_key
         FROM {TIME_SERIES_ASSOCIATIONS_TABLE}
-        WHERE owner_uuid = '{gen1.uuid}'
+        WHERE owner_id = {gen1.id}
     """
     )
     assert len(rows) == 1
     row = rows[0]
     assert row[0] == SimpleGenerator.__name__
     assert row[1] == SingleTimeSeries.__name__
-    assert row[2] == str(gen1.uuid)
-    assert row[3] == str(ts1.uuid)
+    assert row[2] == gen1.id
+    assert row[3] == ts1.id
+    assert row[4] == str(ts1.uuid)
 
 
 def test_time_series_metadata_list_rows():
@@ -662,8 +664,9 @@ def test_time_series_metadata_list_rows():
     columns = [
         "owner_type",
         "time_series_type",
-        "owner_uuid",
-        "time_series_uuid",
+        "owner_id",
+        "time_series_id",
+        "time_series_storage_key",
     ]
     rows = system.time_series.metadata_store.list_rows(
         gen2,
@@ -675,8 +678,9 @@ def test_time_series_metadata_list_rows():
     row = rows[0]
     assert row[0] == SimpleGenerator.__name__
     assert row[1] == SingleTimeSeries.__name__
-    assert row[2] == str(gen2.uuid)
-    assert row[3] == str(ts2.uuid)
+    assert row[2] == gen2.id
+    assert row[3] == ts2.id
+    assert row[4] == str(ts2.uuid)
 
 
 def test_system_counts():

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -952,6 +952,62 @@ def test_bulk_add_time_series_with_rollback(storage_type: TimeSeriesStorageType)
     assert not system.has_time_series(gen, name=ts_name)
 
 
+def test_component_associations_clear():
+    """Test that clearing component associations works correctly."""
+    system = SimpleSystem()
+    bus = SimpleBus(name="bus1", voltage=1.1)
+    gen = SimpleGenerator(name="gen1", active_power=1.0, rating=1.0, bus=bus, available=True)
+    system.add_components(bus, gen)
+
+    # Verify associations exist — generator composes bus
+    children = system._component_mgr._associations.list_child_components(gen)
+    assert len(children) > 0
+    assert bus.id in children
+
+    # Clear all associations
+    system._component_mgr._associations.clear()
+    children = system._component_mgr._associations.list_child_components(gen)
+    assert len(children) == 0
+
+
+def test_component_associations_list_with_type_filter():
+    """Test list_child_components and list_parent_components with type filter."""
+    from infrasys.component import Component
+
+    system = SimpleSystem()
+    bus = SimpleBus(name="bus2", voltage=1.1)
+    gen = SimpleGenerator(name="gen2", active_power=1.0, rating=1.0, bus=bus, available=True)
+    system.add_components(bus, gen)
+
+    # list_child_components with matching type filter — generator composes bus
+    children = system._component_mgr._associations.list_child_components(
+        gen, component_type=Component
+    )
+    assert len(children) >= 1
+    assert bus.id in children
+
+    # list_parent_components with matching type filter — gen's parent
+    parents = system._component_mgr._associations.list_parent_components(
+        bus, component_type=Component
+    )
+    assert len(parents) >= 1
+    assert gen.id in parents
+
+
+def test_get_by_label_with_uuid():
+    """Test that get_by_label works with UUID-based labels."""
+    system = SimpleSystem(auto_add_composed_components=True)
+    bus = SimpleBus(name="uuid-bus", voltage=1.1)
+    system.add_component(bus)
+
+    # Lookup by uuid (via label constructed from uuid)
+    from infrasys.models import make_label
+
+    label = make_label("SimpleBus", str(bus.uuid))
+    found = system.get_component_by_label(label)
+    assert found.id == bus.id
+
+
 def test_remove_component_cleans_up_indexes():
     """Test that removing a component cleans up ID/UUID indexes even when other
     components share the same type/name key (multi-component container)."""

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1041,3 +1041,120 @@ def test_remove_component_cleans_up_indexes():
     system.remove_component(gen2, cascade_down=False)
     with pytest.raises(ISNotStored):
         system.get_component_by_id(gen2.id)
+
+
+def test_get_by_label_with_integer_id():
+    """Test that get_by_label resolves integer ID-based labels."""
+    system = SimpleSystem(auto_add_composed_components=True)
+    gen = SimpleGenerator.example()
+    system.add_component(gen)
+    assert gen.id is not None
+    label = f"SimpleGenerator.{gen.id}"
+    found = system.get_component_by_label(label)
+    assert found.id == gen.id
+
+
+def test_get_by_label_integer_name_wrong_type():
+    """Test that get_by_label raises when an integer-based label matches by ID
+    but the resolved component's type does not match."""
+    system = SimpleSystem(auto_add_composed_components=True)
+    bus = SimpleBus(name="test-bus", voltage=1.1)
+    system.add_component(bus)
+    assert bus.id is not None
+    label = f"SimpleGenerator.{bus.id}"
+    with pytest.raises(ISNotStored, match="No component with"):
+        system.get_component_by_label(label)
+
+
+def test_has_component_with_none_id():
+    """Test that has_component returns False when component has no id."""
+    system = SimpleSystem()
+    gen = SimpleGenerator(name="unattached", active_power=1.0, rating=1.0,
+                          bus=SimpleBus(name="bus", voltage=1.1), available=True)
+    assert gen.id is None
+    assert not system.has_component(gen)
+
+
+def test_serialize_component_reference_without_id():
+    """Test that serialize_component_reference raises ValueError when component has no id."""
+    from infrasys.component import serialize_component_reference
+    gen = SimpleGenerator(name="unattached", active_power=1.0, rating=1.0,
+                          bus=SimpleBus(name="bus", voltage=1.1), available=True)
+    with pytest.raises(ValueError, match="must be attached before it can be serialized"):
+        serialize_component_reference(gen)
+
+
+def test_assign_new_uuid():
+    """Test that assign_new_uuid generates a new legacy UUID."""
+    system = SimpleSystem(auto_add_composed_components=True)
+    gen = SimpleGenerator.example()
+    system.add_component(gen)
+    original_uuid = gen.uuid
+    gen.assign_new_uuid()
+    assert gen.uuid != original_uuid
+
+
+def test_uuid_setter():
+    """Test the uuid property setter."""
+    from uuid import uuid4
+    system = SimpleSystem(auto_add_composed_components=True)
+    gen = SimpleGenerator.example()
+    system.add_component(gen)
+    new_uuid = uuid4()
+    gen.uuid = new_uuid
+    assert gen.uuid == new_uuid
+
+
+def test_example_not_implemented():
+    """Test that Component.example raises NotImplementedError."""
+    from infrasys import Component
+    with pytest.raises(NotImplementedError, match="does not implement example"):
+        Component.example()
+
+
+def test_component_associations_error_no_id():
+    """Test that ComponentAssociations methods raise when component has no id."""
+    system = SimpleSystem()
+    gen = SimpleGenerator(name="unattached", active_power=1.0, rating=1.0,
+                          bus=SimpleBus(name="bus", voltage=1.1), available=True)
+    assoc = system._component_mgr._associations
+
+    with pytest.raises(ISOperationNotAllowed, match="does not have an id"):
+        assoc.list_child_components(gen)
+    with pytest.raises(ISOperationNotAllowed, match="does not have an id"):
+        assoc.list_parent_components(gen)
+    with pytest.raises(ISOperationNotAllowed, match="does not have an id"):
+        assoc.remove(gen)
+
+
+def test_component_associations_make_row_no_id():
+    """Test that _make_row raises when component or attached_component has no id."""
+    system = SimpleSystem()
+    bus = SimpleBus(name="bus1", voltage=1.1)
+    gen = SimpleGenerator(name="gen1", active_power=1.0, rating=1.0, bus=bus, available=True)
+    assoc = system._component_mgr._associations
+
+    with pytest.raises(ISOperationNotAllowed, match="does not have an id"):
+        assoc._make_row(gen, bus)
+
+    system.add_component(bus)
+    with pytest.raises(ISOperationNotAllowed, match="does not have an id"):
+        assoc._make_row(gen, bus)
+
+
+def test_component_add_with_preexisting_id():
+    """Test adding a component with a pre-assigned ID during deserialization."""
+    system = SimpleSystem(auto_add_composed_components=True)
+    gen = SimpleGenerator.example()
+    # Pre-assign an ID that the ID manager hasn't seen yet.
+    gen.id = 42
+    system.add_component(gen)
+    assert gen.id == 42
+    assert system.get_component_by_id(42) is gen
+
+
+def test_supplemental_attribute_get_by_id_not_found():
+    """Test that get_supplemental_attribute_by_id raises when ID is not stored."""
+    system = SimpleSystem()
+    with pytest.raises(ISNotStored, match="No supplemental attribute"):
+        system.get_supplemental_attribute_by_id(999)

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1043,6 +1043,38 @@ def test_remove_component_cleans_up_indexes():
         system.get_component_by_id(gen2.id)
 
 
+def test_rejects_foreign_component_with_colliding_system_local_id():
+    """Components from another system are not attached even if system-local IDs collide."""
+
+    def make_system() -> tuple[SimpleSystem, SimpleGenerator]:
+        bus = SimpleBus(name="bus", voltage=1.1)
+        gen = SimpleGenerator(
+            name="gen",
+            active_power=1.0,
+            rating=1.0,
+            bus=bus,
+            available=True,
+        )
+        system = SimpleSystem(auto_add_composed_components=True)
+        system.add_component(gen)
+        return system, gen
+
+    _, foreign_gen = make_system()
+    system, local_gen = make_system()
+
+    assert foreign_gen.id is not None
+    assert local_gen.id is not None
+    assert foreign_gen.id == local_gen.id
+    assert foreign_gen.uuid != local_gen.uuid
+    assert not system.has_component(foreign_gen)
+
+    with pytest.raises(ISNotStored):
+        system.remove_component(foreign_gen, cascade_down=False)
+
+    assert system.get_component_by_id(local_gen.id) is local_gen
+    assert system.get_component_by_uuid(local_gen.uuid) is local_gen
+
+
 def test_get_by_label_with_integer_id():
     """Test that get_by_label resolves integer ID-based labels."""
     system = SimpleSystem(auto_add_composed_components=True)
@@ -1069,8 +1101,13 @@ def test_get_by_label_integer_name_wrong_type():
 def test_has_component_with_none_id():
     """Test that has_component returns False when component has no id."""
     system = SimpleSystem()
-    gen = SimpleGenerator(name="unattached", active_power=1.0, rating=1.0,
-                          bus=SimpleBus(name="bus", voltage=1.1), available=True)
+    gen = SimpleGenerator(
+        name="unattached",
+        active_power=1.0,
+        rating=1.0,
+        bus=SimpleBus(name="bus", voltage=1.1),
+        available=True,
+    )
     assert gen.id is None
     assert not system.has_component(gen)
 
@@ -1078,8 +1115,14 @@ def test_has_component_with_none_id():
 def test_serialize_component_reference_without_id():
     """Test that serialize_component_reference raises ValueError when component has no id."""
     from infrasys.component import serialize_component_reference
-    gen = SimpleGenerator(name="unattached", active_power=1.0, rating=1.0,
-                          bus=SimpleBus(name="bus", voltage=1.1), available=True)
+
+    gen = SimpleGenerator(
+        name="unattached",
+        active_power=1.0,
+        rating=1.0,
+        bus=SimpleBus(name="bus", voltage=1.1),
+        available=True,
+    )
     with pytest.raises(ValueError, match="must be attached before it can be serialized"):
         serialize_component_reference(gen)
 
@@ -1097,6 +1140,7 @@ def test_assign_new_uuid():
 def test_uuid_setter():
     """Test the uuid property setter."""
     from uuid import uuid4
+
     system = SimpleSystem(auto_add_composed_components=True)
     gen = SimpleGenerator.example()
     system.add_component(gen)
@@ -1108,6 +1152,7 @@ def test_uuid_setter():
 def test_example_not_implemented():
     """Test that Component.example raises NotImplementedError."""
     from infrasys import Component
+
     with pytest.raises(NotImplementedError, match="does not implement example"):
         Component.example()
 
@@ -1115,8 +1160,13 @@ def test_example_not_implemented():
 def test_component_associations_error_no_id():
     """Test that ComponentAssociations methods raise when component has no id."""
     system = SimpleSystem()
-    gen = SimpleGenerator(name="unattached", active_power=1.0, rating=1.0,
-                          bus=SimpleBus(name="bus", voltage=1.1), available=True)
+    gen = SimpleGenerator(
+        name="unattached",
+        active_power=1.0,
+        rating=1.0,
+        bus=SimpleBus(name="bus", voltage=1.1),
+        available=True,
+    )
     assoc = system._component_mgr._associations
 
     with pytest.raises(ISOperationNotAllowed, match="does not have an id"):

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -950,3 +950,38 @@ def test_bulk_add_time_series_with_rollback(storage_type: TimeSeriesStorageType)
             system.add_time_series(ts, gen, context=conn)
 
     assert not system.has_time_series(gen, name=ts_name)
+
+
+def test_remove_component_cleans_up_indexes():
+    """Test that removing a component cleans up ID/UUID indexes even when other
+    components share the same type/name key (multi-component container)."""
+    system = SimpleSystem(auto_add_composed_components=True)
+
+    # Create two generators with the SAME name to exercise the list-container
+    # code path in ComponentManager.remove.
+    bus = SimpleBus(name="shared-bus", voltage=1.1)
+    gen1 = SimpleGenerator(name="gen", active_power=1.0, rating=1.0, bus=bus, available=True)
+    gen2 = SimpleGenerator(name="gen", active_power=2.0, rating=2.0, bus=bus, available=True)
+    system.add_components(bus, gen1, gen2)
+
+    assert gen1.id is not None
+    assert gen2.id is not None
+
+    # Both should be findable by ID
+    assert system.get_component_by_id(gen1.id) is not None
+    assert system.get_component_by_id(gen2.id) is not None
+
+    # Remove gen1
+    system.remove_component(gen1, cascade_down=False)
+
+    # gen1 should no longer be findable by ID
+    with pytest.raises(ISNotStored):
+        system.get_component_by_id(gen1.id)
+
+    # gen2 should still be findable
+    assert system.get_component_by_id(gen2.id) is not None
+
+    # Remove gen2
+    system.remove_component(gen2, cascade_down=False)
+    with pytest.raises(ISNotStored):
+        system.get_component_by_id(gen2.id)


### PR DESCRIPTION
Components, supplemental attributes, and time series metadata now use monotonically-increasing integer IDs as their primary identifier. Legacy UUIDs are preserved as `legacy_uuid` for backward compatibility.

Key changes:
- InfraSysBaseModelWithIdentifiers: new id field (int), legacy_uuid for BC
- IDManager: tracks next available ID, supports advance_past() for serialized data with pre-assigned IDs
- SQLite tables use INTEGER foreign keys with referential integrity
- ComponentAssociations, SupplementalAttributeAssociations, and TimeSeriesMetadataStore all migrated to integer ID columns
- Migration logic for legacy serialized data and existing SQLite schemas
- New get_by_id() methods on ComponentManager, SupplementalAttributeManager
- SerializedComponentReference uses integer id instead of UUID
- Fixed double-negative bug in metadata_store_needs_migration
- copy.deepcopy replaces manual model_dump() reconstruction
- Backward-compat alias InfraSysBaseModelWithIdentifers preserved