### PR TITLE
feat(system): add typed show_components columns

### DIFF
--- a/src/infrasys/__init__.py
+++ b/src/infrasys/__init__.py
@@ -21,6 +21,7 @@ from .location import GeographicInfo, Location
 from .normalization import NormalizationModel
 from .supplemental_attribute import SupplementalAttribute
 from .system import System
+from .system_info import ComponentColumn
 from .time_series_models import (
     Deterministic,
     NonSequentialTimeSeries,
@@ -33,6 +34,7 @@ from .time_series_models import (
 __all__ = (
     "BaseQuantity",
     "Component",
+    "ComponentColumn",
     "Deterministic",
     "DeviceParameter",
     "GeographicInfo",

--- a/src/infrasys/system.py
+++ b/src/infrasys/system.py
@@ -8,14 +8,21 @@ from collections import defaultdict
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Generator, Iterable, Literal, Optional, Type, TypeAlias, TypeVar
+from typing import (
+    Any,
+    Callable,
+    Generator,
+    Iterable,
+    Literal,
+    Optional,
+    Type,
+    TypeAlias,
+    TypeVar,
+)
 from uuid import UUID, uuid4
 
 import orjson
 from loguru import logger
-from rich import print as _pprint
-from rich.table import Table
-
 from .component import (
     Component,
 )
@@ -44,6 +51,7 @@ from .serialization import (
     SerializedType,
     SerializedTypeMetadata,
 )
+from .system_info import ComponentColumnInput, SystemInfo, render_components_table
 from .supplemental_attribute import SupplementalAttribute
 from .supplemental_attribute_manager import SupplementalAttributeManager
 from .time_series_manager import TIME_SERIES_KWARGS, TimeSeriesManager
@@ -55,7 +63,6 @@ from .time_series_models import (
     TimeSeriesStorageContext,
 )
 from .utils.sqlite import backup, create_in_memory_db, restore
-from .utils.time_utils import from_iso_8601
 
 T = TypeVar("T", bound="Component")
 U = TypeVar("U", bound="SupplementalAttribute")
@@ -1750,10 +1757,12 @@ class System:
 
     def show_components(
         self,
-        component_type: Type[Component],
+        component_type: Type[T],
+        columns: ComponentColumnInput | bool | None = None,
         show_uuid: bool = False,
         show_time_series: bool = False,
         show_supplemental: bool = False,
+        filter_func: Callable[[T], bool] | None = None,
     ) -> None:
         """Display a table of components of the specified type.
 
@@ -1762,174 +1771,41 @@ class System:
         component_type : Type[Component]
             The type of components to display. If component_type is an abstract type,
             all matching subtypes will be included.
+        columns : str | ComponentColumn | tuple | list | bool | None
+            Component field name(s) or computed column specifications to include after the
+            Name column. A bare string is treated as one field name. Passing a bool preserves
+            compatibility with legacy positional ``show_uuid`` calls.
         show_uuid : bool
             Whether to include the UUID column in the table. Defaults to False.
         show_time_series : bool
             Whether to include the Time Series count column in the table. Defaults to False.
-        show_time_series : bool
+        show_supplemental : bool
             Whether to include the Supplemental Attributes count column in the table. Defaults to False.
+        filter_func : Callable | None
+            Optional function to filter the displayed components. The function must accept a
+            component as a single argument.
 
         Examples
         --------
         >>> system.show_components(Generator)  # Shows only names
-        >>> system.show_components(Bus, show_uuid=True)
+        >>> system.show_components(Bus, "voltage")
+        >>> system.show_components(Bus, ("name", "voltage"))
         >>> system.show_components(Generator, show_time_series=True)
         >>> system.show_components(Generator, show_supplemental=True)
         """
-        components = list(self.get_components(component_type))
-
-        if not components:
-            logger.warning(f"No components of type {component_type.__name__} found in the system.")
-            return
-
-        table = Table(
-            title=f"{component_type.__name__}: {len(components)}",
-            show_header=True,
-            title_justify="left",
-            title_style="bold",
+        if isinstance(columns, bool):
+            show_uuid = columns
+            columns = None
+        render_components_table(
+            self,
+            component_type,
+            columns,
+            show_uuid=show_uuid,
+            show_time_series=show_time_series,
+            show_supplemental=show_supplemental,
+            filter_func=filter_func,
         )
-        table.add_column("Name", min_width=20, justify="left")
-
-        if show_uuid:
-            table.add_column("UUID", min_width=36, justify="left")
-        if show_time_series:
-            table.add_column("Has Time Series", min_width=12, justify="right")
-        if show_supplemental:
-            table.add_column("Has Supplemental Attributes", min_width=12, justify="right")
-
-        sorted_components = sorted(components, key=lambda x: getattr(x, "name", x.label))
-
-        for component in sorted_components:
-            row_data = [component.name]
-
-            if show_uuid:
-                row_data.append(str(component.uuid))
-            if show_time_series:
-                row_data.append(str(len(self.list_time_series_metadata(component))))
-            if show_supplemental:
-                row_data.append(
-                    str(len(self.get_supplemental_attributes_with_component(component)))
-                )
-
-            table.add_row(*row_data)
-
-        _pprint(table)
 
     def info(self):
         info = SystemInfo(system=self)
         info.render()
-
-
-class SystemInfo:
-    """Class to store system component info"""
-
-    def __init__(self, system) -> None:
-        self.system = system
-
-    def extract_system_counts(self) -> tuple[int, int, dict, dict]:
-        component_count = self.system._components.get_num_components()
-        component_type_count = {
-            k.__name__: v for k, v in self.system._components.get_num_components_by_type().items()
-        }
-        ts_counts = self.system.time_series.metadata_store.get_time_series_counts()
-        return (
-            component_count,
-            ts_counts.time_series_count,
-            component_type_count,
-            ts_counts.time_series_type_count,
-        )
-
-    def render(self) -> None:
-        """Render Summary information from the system."""
-        (
-            component_count,
-            time_series_count,
-            component_type_count,
-            time_series_type_count,
-        ) = self.extract_system_counts()
-        owner_type_count = self._get_owner_type_counts(component_type_count)
-
-        # System table
-        system_table = Table(
-            title="System",
-            show_header=True,
-            title_justify="left",
-            title_style="bold",
-        )
-        system_table.add_column("Property")
-        system_table.add_column("Value", justify="right")
-        system_table.add_row("System name", self.system.name)
-        system_table.add_row("Data format version", self.system._data_format_version)
-        system_table.add_row("Components attached", f"{component_count}")
-        system_table.add_row("Time Series attached", f"{time_series_count}")
-        total_suppl_attrs = self.system.get_num_supplemental_attributes()
-        system_table.add_row("Supplemental Attributes attached", f"{total_suppl_attrs}")
-        system_table.add_row("Description", self.system.description)
-        _pprint(system_table)
-
-        # Component and time series table
-        component_table = Table(
-            title="Component Information",
-            show_header=True,
-            title_justify="left",
-            title_style="bold",
-        )
-        component_table.add_column("Type", min_width=20)
-        component_table.add_column("Count", justify="right")
-
-        for component_type, component_count in sorted(component_type_count.items()):
-            component_table.add_row(
-                f"{component_type}",
-                f"{component_count}",
-            )
-
-        if component_table.rows:
-            _pprint(component_table)
-
-        time_series_table = Table(
-            title="Time Series Summary",
-            show_header=True,
-            title_justify="left",
-            title_style="bold",
-        )
-        time_series_table.add_column("Owner Type", min_width=20)
-        time_series_table.add_column("Time Series Type", justify="right")
-        time_series_table.add_column("Initial time", justify="right")
-        time_series_table.add_column("Resolution", justify="right")
-        time_series_table.add_column("No. Components", justify="right")
-        time_series_table.add_column("No. Components with Time Series", justify="right")
-
-        for (
-            component_type,
-            time_series_type,
-            time_series_start_time,
-            time_series_resolution,
-        ), time_series_count in sorted(
-            time_series_type_count.items(),
-            key=lambda item: tuple(v if v is not None else "" for v in item[0]),
-        ):
-            owner_count = owner_type_count.get(component_type, 0)
-            time_series_table.add_row(
-                f"{component_type}",
-                f"{time_series_type}",
-                f"{time_series_start_time}" if time_series_start_time is not None else "N/A",
-                f"{from_iso_8601(time_series_resolution)}"
-                if time_series_resolution is not None
-                else "N/A",
-                f"{owner_count}",
-                f"{time_series_count}",
-            )
-
-        if time_series_table.rows:
-            _pprint(time_series_table)
-
-    def _get_owner_type_counts(self, component_type_count: dict[str, int]) -> dict[str, int]:
-        """Combine component and supplemental attribute counts by type for summary tables."""
-        owner_type_count = dict(component_type_count)
-        supplemental_attribute_counts: dict[str, int] = defaultdict(int)
-
-        for attribute in self.system._supplemental_attr_mgr.iter_all():
-            supplemental_attribute_counts[type(attribute).__name__] += 1
-
-        owner_type_count.update(supplemental_attribute_counts)
-        return owner_type_count

--- a/src/infrasys/system_info.py
+++ b/src/infrasys/system_info.py
@@ -1,0 +1,294 @@
+"""Rendering helpers for system information tables."""
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable, Generic, Type, TypeAlias, TypeVar
+
+from loguru import logger
+from rich import print as _pprint
+from rich.table import Table
+
+from .component import Component
+from .exceptions import ISInvalidParameter
+from .utils.time_utils import from_iso_8601
+
+if TYPE_CHECKING:
+    from .system import System
+
+T = TypeVar("T", bound="Component")
+
+
+@dataclass(frozen=True)
+class ComponentColumn(Generic[T]):
+    """Computed column specification for :meth:`System.show_components`.
+
+    Parameters
+    ----------
+    name : str
+        Column header to display.
+    extractor : Callable[[T], Any]
+        Callable that returns the value to render for a component.
+    """
+
+    name: str
+    extractor: Callable[[T], Any]
+
+
+ComponentColumnInput: TypeAlias = (
+    str
+    | ComponentColumn[Any]
+    | tuple[str | ComponentColumn[Any], ...]
+    | list[str | ComponentColumn[Any]]
+)
+
+
+def render_components_table(
+    system: "System",
+    component_type: Type[T],
+    columns: ComponentColumnInput | None,
+    *,
+    show_uuid: bool,
+    show_time_series: bool,
+    show_supplemental: bool,
+    filter_func: Callable[[T], bool] | None,
+) -> None:
+    """Render components of ``component_type`` as a Rich table."""
+    component_columns = normalize_component_columns(component_type, columns)
+    components = list(system.get_components(component_type, filter_func=filter_func))
+
+    if not components:
+        logger.warning(f"No components of type {component_type.__name__} found in the system.")
+        return
+
+    table = Table(
+        title=f"{component_type.__name__}: {len(components)}",
+        show_header=True,
+        title_justify="left",
+        title_style="bold",
+    )
+    table.add_column("Name", min_width=20, justify="left")
+
+    for column in component_columns:
+        table.add_column(column.name, justify="left")
+    add_component_metadata_columns(
+        table,
+        show_uuid=show_uuid,
+        show_time_series=show_time_series,
+        show_supplemental=show_supplemental,
+    )
+
+    sorted_components = sorted(components, key=lambda x: getattr(x, "name", x.label))
+
+    for component in sorted_components:
+        row_data = [component.name]
+        row_data.extend(render_component_column(component, column) for column in component_columns)
+        extend_component_metadata_row(
+            system,
+            row_data,
+            component,
+            show_uuid=show_uuid,
+            show_time_series=show_time_series,
+            show_supplemental=show_supplemental,
+        )
+        table.add_row(*row_data)
+
+    _pprint(table)
+
+
+def add_component_metadata_columns(
+    table: Table,
+    *,
+    show_uuid: bool,
+    show_time_series: bool,
+    show_supplemental: bool,
+) -> None:
+    if show_uuid:
+        table.add_column("UUID", min_width=36, justify="left")
+    if show_time_series:
+        table.add_column("Has Time Series", min_width=12, justify="right")
+    if show_supplemental:
+        table.add_column("Has Supplemental Attributes", min_width=12, justify="right")
+
+
+def extend_component_metadata_row(
+    system: "System",
+    row_data: list[str],
+    component: Component,
+    *,
+    show_uuid: bool,
+    show_time_series: bool,
+    show_supplemental: bool,
+) -> None:
+    if show_uuid:
+        row_data.append(str(component.uuid))
+    if show_time_series:
+        row_data.append(str(len(system.list_time_series_metadata(component))))
+    if show_supplemental:
+        row_data.append(str(len(system.get_supplemental_attributes_with_component(component))))
+
+
+def normalize_component_columns(
+    component_type: Type[T], columns: ComponentColumnInput | None
+) -> list[ComponentColumn[T]]:
+    if columns is None:
+        return []
+    if isinstance(columns, str | ComponentColumn):
+        column_specs = [columns]
+    elif isinstance(columns, tuple | list):
+        column_specs = list(columns)
+    else:
+        msg = (
+            f"Invalid columns specification for {component_type.__name__}: "
+            f"expected a field name, ComponentColumn, tuple, or list; got {type(columns).__name__}."
+        )
+        raise ISInvalidParameter(msg)
+
+    normalized: list[ComponentColumn[T]] = []
+    for column in column_specs:
+        if isinstance(column, str):
+            normalized.append(make_component_field_column(component_type, column))
+        elif isinstance(column, ComponentColumn):
+            normalized.append(column)
+        else:
+            msg = (
+                f"Invalid column {column!r} for {component_type.__name__}: "
+                "expected a field name or ComponentColumn."
+            )
+            raise ISInvalidParameter(msg)
+    return normalized
+
+
+def make_component_field_column(component_type: Type[T], field_name: str) -> ComponentColumn[T]:
+    if field_name not in component_type.model_fields:
+        msg = f"Column {field_name!r} does not exist on component type {component_type.__name__}."
+        raise ISInvalidParameter(msg)
+    return ComponentColumn(
+        name=field_name, extractor=lambda component: getattr(component, field_name)
+    )
+
+
+def render_component_column(component: T, column: ComponentColumn[T]) -> str:
+    try:
+        value = column.extractor(component)
+    except Exception as exc:
+        msg = (
+            f"Failed to compute column {column.name!r} for component {component.label} "
+            f"({type(component).__name__})."
+        )
+        raise ISInvalidParameter(msg) from exc
+    if value is None:
+        return ""
+    return str(value)
+
+
+class SystemInfo:
+    """Class to store system component info."""
+
+    def __init__(self, system: "System") -> None:
+        self.system = system
+
+    def extract_system_counts(self) -> tuple[int, int, dict, dict]:
+        component_count = self.system._components.get_num_components()
+        component_type_count = {
+            k.__name__: v for k, v in self.system._components.get_num_components_by_type().items()
+        }
+        ts_counts = self.system.time_series.metadata_store.get_time_series_counts()
+        return (
+            component_count,
+            ts_counts.time_series_count,
+            component_type_count,
+            ts_counts.time_series_type_count,
+        )
+
+    def render(self) -> None:
+        """Render Summary information from the system."""
+        (
+            component_count,
+            time_series_count,
+            component_type_count,
+            time_series_type_count,
+        ) = self.extract_system_counts()
+        owner_type_count = self._get_owner_type_counts(component_type_count)
+
+        system_table = Table(
+            title="System",
+            show_header=True,
+            title_justify="left",
+            title_style="bold",
+        )
+        system_table.add_column("Property")
+        system_table.add_column("Value", justify="right")
+        system_table.add_row("System name", self.system.name)
+        system_table.add_row("Data format version", self.system._data_format_version)
+        system_table.add_row("Components attached", f"{component_count}")
+        system_table.add_row("Time Series attached", f"{time_series_count}")
+        total_suppl_attrs = self.system.get_num_supplemental_attributes()
+        system_table.add_row("Supplemental Attributes attached", f"{total_suppl_attrs}")
+        system_table.add_row("Description", self.system.description)
+        _pprint(system_table)
+
+        component_table = Table(
+            title="Component Information",
+            show_header=True,
+            title_justify="left",
+            title_style="bold",
+        )
+        component_table.add_column("Type", min_width=20)
+        component_table.add_column("Count", justify="right")
+
+        for component_type, component_count in sorted(component_type_count.items()):
+            component_table.add_row(
+                f"{component_type}",
+                f"{component_count}",
+            )
+
+        if component_table.rows:
+            _pprint(component_table)
+
+        time_series_table = Table(
+            title="Time Series Summary",
+            show_header=True,
+            title_justify="left",
+            title_style="bold",
+        )
+        time_series_table.add_column("Owner Type", min_width=20)
+        time_series_table.add_column("Time Series Type", justify="right")
+        time_series_table.add_column("Initial time", justify="right")
+        time_series_table.add_column("Resolution", justify="right")
+        time_series_table.add_column("No. Components", justify="right")
+        time_series_table.add_column("No. Components with Time Series", justify="right")
+
+        for (
+            component_type,
+            time_series_type,
+            time_series_start_time,
+            time_series_resolution,
+        ), time_series_count in sorted(
+            time_series_type_count.items(),
+            key=lambda item: tuple(v if v is not None else "" for v in item[0]),
+        ):
+            owner_count = owner_type_count.get(component_type, 0)
+            time_series_table.add_row(
+                f"{component_type}",
+                f"{time_series_type}",
+                f"{time_series_start_time}" if time_series_start_time is not None else "N/A",
+                f"{from_iso_8601(time_series_resolution)}"
+                if time_series_resolution is not None
+                else "N/A",
+                f"{owner_count}",
+                f"{time_series_count}",
+            )
+
+        if time_series_table.rows:
+            _pprint(time_series_table)
+
+    def _get_owner_type_counts(self, component_type_count: dict[str, int]) -> dict[str, int]:
+        """Combine component and supplemental attribute counts by type for summary tables."""
+        owner_type_count = dict(component_type_count)
+        supplemental_attribute_counts: dict[str, int] = defaultdict(int)
+
+        for attribute in self.system._supplemental_attr_mgr.iter_all():
+            supplemental_attribute_counts[type(attribute).__name__] += 1
+
+        owner_type_count.update(supplemental_attribute_counts)
+        return owner_type_count

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,16 +1,25 @@
 import itertools
 from datetime import datetime, timedelta
+from typing import Any
 from uuid import uuid4
 
 import numpy as np
 import pytest
 
-from infrasys import TIME_SERIES_ASSOCIATIONS_TABLE, Component, Location, SingleTimeSeries
+import infrasys.system_info as system_info_module
+from infrasys import (
+    TIME_SERIES_ASSOCIATIONS_TABLE,
+    Component,
+    ComponentColumn,
+    Location,
+    SingleTimeSeries,
+)
 from infrasys.arrow_storage import ArrowTimeSeriesStorage
 from infrasys.chronify_time_series_storage import ChronifyTimeSeriesStorage
 from infrasys.exceptions import (
     ISAlreadyAttached,
     ISConflictingArguments,
+    ISInvalidParameter,
     ISNotStored,
     ISOperationNotAllowed,
 )
@@ -747,6 +756,106 @@ def test_system_show_components(simple_system_with_time_series):
     simple_system_with_time_series.show_components(SimpleBus, show_uuid=True)
     simple_system_with_time_series.show_components(SimpleBus, show_time_series=True)
     simple_system_with_time_series.show_components(SimpleBus, show_supplemental=True)
+    simple_system_with_time_series.show_components(SimpleBus, True)
+
+
+@pytest.mark.parametrize("columns", ["voltage", ("voltage", "name"), ["voltage", "name"]])
+def test_system_show_components_with_component_fields(
+    simple_system_with_time_series,
+    capsys,
+    columns,
+):
+    simple_system_with_time_series.show_components(SimpleBus, columns)
+
+    output = capsys.readouterr().out
+    assert "voltage" in output
+    assert "1.1" in output
+    assert "test-bus" in output
+
+
+def test_system_show_components_with_computed_column(simple_system_with_time_series, capsys):
+    column = ComponentColumn[SimpleBus](
+        name="double_voltage",
+        extractor=lambda component: component.voltage * 2,
+    )
+
+    simple_system_with_time_series.show_components(SimpleBus, column)
+
+    output = capsys.readouterr().out
+    assert "double_voltage" in output
+    assert "2.2" in output
+
+
+def test_system_show_components_with_columns_and_metadata(
+    simple_system_with_time_series,
+    monkeypatch,
+):
+    rendered_tables: list[Any] = []
+    monkeypatch.setattr(system_info_module, "_pprint", rendered_tables.append)
+
+    simple_system_with_time_series.show_components(
+        SimpleBus,
+        "voltage",
+        show_uuid=True,
+        show_time_series=True,
+        show_supplemental=True,
+    )
+
+    assert len(rendered_tables) == 1
+    columns = [column.header for column in rendered_tables[0].columns]
+    assert columns == [
+        "Name",
+        "voltage",
+        "UUID",
+        "Has Time Series",
+        "Has Supplemental Attributes",
+    ]
+
+
+def test_system_show_components_with_filter_func(simple_system_with_time_series, capsys):
+    simple_system_with_time_series.show_components(
+        SimpleBus,
+        "voltage",
+        filter_func=lambda component: component.name == "not-present",
+    )
+
+    output = capsys.readouterr().out
+    assert output == ""
+
+
+def test_system_show_components_invalid_field_name(simple_system_with_time_series):
+    with pytest.raises(ISInvalidParameter, match="missing.*SimpleBus"):
+        simple_system_with_time_series.show_components(SimpleBus, "missing")
+
+
+@pytest.mark.parametrize("columns", [1, ["voltage", 1]])
+def test_system_show_components_invalid_column_specs(simple_system_with_time_series, columns):
+    invalid_columns: Any = columns
+
+    with pytest.raises(ISInvalidParameter, match="SimpleBus"):
+        simple_system_with_time_series.show_components(SimpleBus, invalid_columns)
+
+
+def test_system_show_components_with_empty_computed_value(simple_system_with_time_series, capsys):
+    simple_system_with_time_series.show_components(
+        SimpleBus,
+        ComponentColumn[SimpleBus](name="empty", extractor=lambda _component: None),
+    )
+
+    output = capsys.readouterr().out
+    assert "empty" in output
+
+
+def test_system_show_components_computed_column_failure(simple_system_with_time_series):
+    def fail(_component: SimpleBus) -> float:
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    with pytest.raises(ISInvalidParameter, match="broken.*SimpleBus.test-bus"):
+        simple_system_with_time_series.show_components(
+            SimpleBus,
+            ComponentColumn[SimpleBus](name="broken", extractor=fail),
+        )
 
 
 def test_system_info_renders_supplemental_attributes_table(


### PR DESCRIPTION
Closes #159

## Summary

- Draft PR: not ready to merge until validation and review are complete.
- Adds public `ComponentColumn[T]` support for computed `System.show_components()` columns.
- Allows `show_components()` to render selected component fields from a bare string, tuple, or list.
- Adds `filter_func` support and clear `ISInvalidParameter` errors for invalid fields and failed computed-column extractors.
- Keeps display/table-rendering support in `system_info.py`, with `System.show_components()` as a thin public API wrapper.

## Acceptance criteria

- [x] Existing supported calls continue to work: `show_components(ComponentType)`, `show_components(ComponentType, show_uuid=True)`, `show_components(ComponentType, show_time_series=True)`, and `show_components(ComponentType, show_supplemental=True)`.
  - Evidence: `test_system_show_components` covers the existing call shapes.
- [x] `show_components(ComponentType, "field_name")` renders that component field as one additional column.
  - Evidence: `test_system_show_components_with_component_fields` covers bare string input.
- [x] `show_components(ComponentType, ("field_a", "field_b"))` renders multiple additional columns.
  - Evidence: `test_system_show_components_with_component_fields` covers tuple input.
- [x] `show_components(ComponentType, ["field_a", "field_b"])` renders multiple additional columns.
  - Evidence: `test_system_show_components_with_component_fields` covers list input.
- [x] A typed `ComponentColumn[T]` or equivalent supports computed columns with callable extractors.
  - Evidence: `test_system_show_components_with_computed_column` covers `ComponentColumn[SimpleBus]`.
- [x] `filter_func` is accepted and applied to the same selected component subtype as `component_type`.
  - Evidence: `test_system_show_components_with_filter_func` filters `SimpleBus` rows.
- [x] Invalid field names raise a clear `infrasys` exception that identifies the missing column and component involved.
  - Evidence: `test_system_show_components_invalid_field_name` asserts `ISInvalidParameter` mentions the field and `SimpleBus`.
- [x] Failing computed-column extractors raise a clear `infrasys` exception that identifies the failing column and component involved.
  - Evidence: `test_system_show_components_computed_column_failure` asserts `ISInvalidParameter` mentions the column and component label.
- [x] Bare strings are treated as one column name, not as an iterable of characters.
  - Evidence: bare string `"voltage"` renders successfully as a field column.
- [x] Legacy keyword metadata toggles remain keyword-compatible.
  - Evidence: metadata keyword toggles are preserved and covered with/without selected columns.

## Deviations from the original plan

- `uv run mypy src tests` still reports unrelated pre-existing errors in supplemental attribute code/tests; touched files pass `uv run mypy src/infrasys/system.py src/infrasys/system_info.py tests/test_system.py`.

## Testing Strategy

```bash
uv run pytest tests/test_system.py -k 'show_components or system_info'
uv run ruff check src tests
uv run ruff format src tests --check
uv run mypy src/infrasys/system.py src/infrasys/system_info.py tests/test_system.py
uv run mypy src tests
```

## References

- https://github.com/NatLabRockies/infrasys/issues/159
